### PR TITLE
ci: exempt dependabot from CHANGELOG requirement

### DIFF
--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -28,7 +28,8 @@ jobs:
       - name: Check CHANGELOG.md updated
         run: |
           # Skip for dependabot PRs (automated dependency bumps)
-          if [ "${{ github.actor }}" = "dependabot[bot]" ]; then
+          # Use event.pull_request.user.login (stable across reruns) not github.actor
+          if [ "${{ github.event.pull_request.user.login }}" = "dependabot[bot]" ]; then
             echo "CHANGELOG.md: skipped (dependabot PR)"
             exit 0
           fi


### PR DESCRIPTION
## Summary
- Dependabot PRs are automatically exempted from the CHANGELOG.md requirement (automated bots can't edit it)
- Added `packages.lock.json` to the skip list for non-docs detection

## Test plan
- [ ] Verify PR #73 governance check passes after this merges
- [ ] Verify human PRs still require CHANGELOG.md updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI validation updated to automatically skip changelog checks for automated dependency PRs.
  * Lockfile changes are now excluded from triggering required changelog updates, reducing false-positive validation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->