### PR TITLE
fix(runtime-ui): populate F9/F10 panels on open, wire ContextualModMenuHost (#30 #31 #32 #33)

### DIFF
--- a/src/Runtime/Plugin.cs
+++ b/src/Runtime/Plugin.cs
@@ -659,10 +659,17 @@ namespace DINOForge.Runtime
 
                 _modPlatform.SetUI(_dfCanvas.ModMenuPanel, settingsHost);
 
-                // Wire the active UGUI menu host into NativeMenuInjector for the native Mods button
+                // Fix #30: route the native Mods button through ContextualModMenuHost so
+                // that when NativeMainMenuModMenu.CanUseNativeScreen becomes true (M11.5),
+                // the native menu takes over automatically without re-wiring.
+                // For now CanUseNativeScreen returns false, so overlay is still used.
                 if (_nativeMenuInjector != null)
                 {
-                    _nativeMenuInjector.SetModMenuHost(_dfCanvas.ModMenuPanel);
+                    NativeMainMenuModMenu nativeHost = new NativeMainMenuModMenu();
+                    ContextualModMenuHost contextualHost = new ContextualModMenuHost(
+                        _dfCanvas.ModMenuPanel, nativeHost);
+                    _nativeMenuInjector.SetModMenuHost(contextualHost);
+                    _log.LogInfo("[RuntimeDriver] NativeMenuInjector wired via ContextualModMenuHost (native stub active, overlay fallback).");
                 }
 
                 // Wire UGUI DebugPanel to ModPlatform so it displays platform status
@@ -683,6 +690,17 @@ namespace DINOForge.Runtime
                 }
 
                 _log.LogInfo("[RuntimeDriver] UGUI wired to ModPlatform via IModMenuHost.");
+
+                // Fix #31/#32: LoadPacks() may have run before the UI host was wired
+                // (ModPlatform.UpdateUI() returns early when _modMenuHost is null).
+                // Now that the host is registered, replay a LoadPacks() so ModMenuPanel
+                // receives the pack list and DebugPanel receives ModPlatform data.
+                // This is a no-op if packs have not been loaded yet.
+                if (_modPlatform.GetLoadedPackIds() != null)
+                {
+                    _log.LogInfo("[RuntimeDriver] Replaying LoadPacks() to populate UGUI panels after late wiring.");
+                    _modPlatform.LoadPacks();
+                }
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary

- **Fixes #31** (F9 body empty) and **Fixes #32** (F10 sidebar empty): Root cause was a load-order race — `LoadPacks()` runs inside `OnWorldReady()` which fires before `WireUguiToModPlatform()` sets `_modMenuHost` on `ModPlatform`. `ModPlatform.UpdateUI()` returned early with `_modMenuHost == null`, so pack data never reached `ModMenuPanel` and `ModPlatform` was never injected into `DebugPanel`.

  Fix: after `WireUguiToModPlatform()` successfully registers the host, replay `LoadPacks()` when packs have already been loaded (guarded by `GetLoadedPackIds() != null`). This populates `ModMenuPanel`'s pack list and gives `DebugPanel` its `ModPlatform` reference.

- **Fixes #33** (enable/disable not persisting): `ModMenuPanel.OnToggleSelected()` fires `OnPackToggled?.Invoke(...)`, but `OnPackToggled` was null before UGUI wiring completed. The wiring fix above ensures the callback is set before the user can interact with the panel.

- **Partially addresses #30** (Mods button opens overlay): Route `NativeMenuInjector` through `ContextualModMenuHost` wrapping the overlay so the system is ready to switch to a native main-menu screen when `NativeMainMenuModMenu.CanUseNativeScreen` becomes true (M11.5 / WI-004a). Today the stub returns `false` so the overlay fallback is unchanged.

## Root Cause Diagram

```
OnWorldReady()
  └─ LoadPacks()
       └─ UpdateUI()
            └─ _modMenuHost == null → RETURN EARLY (pack data dropped)

... one Update() tick later ...

Update()
  └─ _dfCanvas.IsReady == true
       └─ WireUguiToModPlatform()
            └─ _modPlatform.SetUI(ModMenuPanel, ...)   ← _modMenuHost finally set
            └─ BEFORE THIS FIX: done, panels stay empty
            └─ AFTER THIS FIX:  LoadPacks() replayed → panels populated
```

## Test plan

- [ ] Start game, wait for ECS world, press F10 — pack list sidebar should show loaded packs.
- [ ] Press F9 — Platform Status section should show ModPlatform state; Errors section should show any pack load errors.
- [ ] Toggle a pack on/off in F10 panel — state should persist after game restart (check `disabled_packs.json` in packs directory).
- [ ] Verify Mods button in native menu still opens the overlay (expected while `CanUseNativeScreen == false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)