### PR TITLE
feat(docs): add AgilePlus methodology spec for DINOForge

### DIFF
--- a/docs/plans/AGILEPLUS_SPEC.md
+++ b/docs/plans/AGILEPLUS_SPEC.md
@@ -3,17 +3,19 @@
 **Version**: 1.0.0
 **Status**: Active
 **Last Updated**: 2026-03-31
+**Rig ID**: `6c6d4555-91e8-4f06-a974-018cf3e766d2`
+**Town**: `78a8d430-a206-4a25-96c0-5cd9f5caf984`
 **Audience**: All contributors, agents, and maintainers
 
 ---
 
 ## 1. Overview
 
-This document describes how **AgilePlus** — the spec-driven development engine at `kooshapari/agileplus` — is applied to the DINOForge project. It defines the conventions, workflows, and governance rules that govern how features are specified, implemented, validated, and shipped in this repository.
-
 ### 1.1 What is AgilePlus?
 
-AgilePlus is a **spec-driven development engine** that inverts the typical development workflow. Instead of jumping from idea to code, every feature begins as a **specification** — a structured document that defines:
+**AgilePlus** (`kooshapari/agileplus`) is the **spec-driven development engine** governing DINOForge project management. It implements an 8-phase pipeline with cryptographic audit trails, work package decomposition, and agent-agnostic dispatch.
+
+AgilePlus inverts the typical development workflow. Instead of jumping from idea to code, every feature begins as a **specification** — a structured document that defines:
 
 - What gets built and why
 - Who the actors and users are
@@ -21,14 +23,6 @@ AgilePlus is a **spec-driven development engine** that inverts the typical devel
 - Explicit scope boundaries
 - Assumptions and dependencies
 - Trade-offs and design rationale
-
-AgilePlus enforces an **8-stage governed pipeline**:
-
-```
-Created → Specified → Researched → Planned → Implementing → Validated → Shipped → Retrospected
-```
-
-Every state transition is recorded with cryptographic integrity (SHA-256 hash chain) and is auditable. No stage can be skipped. No work ships without validation.
 
 ### 1.2 AgilePlus in the DINOForge Ecosystem
 
@@ -40,13 +34,71 @@ DINOForge participates in a multi-repo AgilePlus ecosystem:
 | `kooshapari/Dino` (this repo) | Mod platform | Consumes AgilePlus; specs live in `docs/plans/` |
 | `AgilePlus-*` convoy repos | Content packs | Feature branches track AgilePlus work packages |
 
-The **DINO Forge Town** (rig `78a8d430-a206-4a25-96c0-5cd9f5caf984`) coordinates work across all repos using **Kilo Gastown** — a multi-agent orchestration system that dispatches polecat agents to work items (beads) tracked in AgilePlus.
+The **DINOForge Town** (rig `78a8d430-a206-4a25-96c0-5cd9f5caf984`) coordinates work across all repos using **Kilo Gastown** — a multi-agent orchestration system that dispatches polecat agents to work items (beads) tracked in AgilePlus.
+
+**Dashboard URL**: `https://kooshapari.github.io/AgilePlus`
 
 ---
 
-## 2. DINOForge-Specific AgilePlus Conventions
+## 2. Core Concepts
 
-### 2.1 Spec Location and Naming
+### 2.1 8-Phase Pipeline
+
+Every feature flows through a deterministic state machine:
+
+```
+Created → Specified → Researched → Planned → Implementing → Validated → Shipped → Retrospected
+```
+
+Every state transition is recorded with cryptographic integrity (SHA-256 hash chain) and is auditable. No stage can be skipped. No work ships without validation.
+
+| Phase | Purpose | Key Artifact |
+|-------|---------|--------------|
+| **Created** | Feature idea recorded | Feature slug, title, target branch |
+| **Specified** | Requirements documented | `spec.md` with functional requirements, acceptance criteria |
+| **Researched** | Feasibility assessed | `research.md` with codebase scan, risk analysis |
+| **Planned** | Work decomposed | `plan.md` with work packages and dependency graph |
+| **Implementing** | Code written | Work packages in isolated branches |
+| **Validated** | Quality verified | Test results, lint output, security scans |
+| **Shipped** | Deployed | Merged to target branch |
+| **Retrospected** | Lessons learned | `retrospective.md` with metrics and action items |
+
+### 2.2 Work Packages (WPs)
+
+Large features decompose into **work packages** — small, independently implementable units with:
+
+- Unique ID (WP01, WP02, etc.)
+- Isolated git branch (`feature/my-feature/WP01`)
+- Clear acceptance criteria (boolean success conditions)
+- Defined file scope (which source files can be touched)
+- Dependency tracking (explicit + file-overlap + data dependencies)
+
+### 2.3 Governance by Default
+
+Every state transition enforces preconditions:
+
+- Cannot move to `Specified` without a valid `spec.md`
+- Cannot move to `Planned` without research output
+- Cannot move to `Implementing` without work packages assigned
+- Cannot `Ship` without all validation passing
+
+Evidence artifacts (test results, CI output, reviews) are recorded and chained with SHA-256 hashes.
+
+### 2.4 Agent-Agnostic Dispatch
+
+AgilePlus supports multiple AI agents through structured prompts:
+
+- **Claude Code** — CLI dispatch with structured prompt
+- **Cursor** — rule files + slash commands
+- **Custom agents** — via gRPC API
+
+All agents receive: spec context, plan context, WP definition, acceptance criteria, and file scope.
+
+---
+
+## 3. DINOForge-Specific Conventions
+
+### 3.1 Spec Location and Naming
 
 Feature specs are stored in `docs/plans/` with the naming convention:
 
@@ -57,29 +109,10 @@ docs/plans/<FEATURE_NAME>_SPEC.md
 Example:
 ```
 docs/plans/AGILEPLUS_SPEC.md      ← This document
-docs/plans/ASSET_PIPELINE_SPEC.md
-docs/plans/MCP_BRIDGE_SPEC.md
+docs/plans/KILO_GASTOWN_SPEC.md
 ```
 
-Each spec file includes:
-
-- **Spec Hash**: SHA-256 hash computed on creation for immutable tracking
-- **Feature ID**: Auto-incremented identifier (e.g., `SPEC-001`, `SPEC-002`)
-- **Status**: Current AgilePlus pipeline stage
-- **Owner**: Agent or developer responsible
-- **FR IDs**: Functional requirement identifiers (FR-001, FR-002, etc.)
-
-### 2.2 Feature ID Format
-
-Features use the pattern: `SPEC-<NNN>`
-
-Examples: `SPEC-001`, `SPEC-002`, `SPEC-010`
-
-Work packages within a feature use: `WP-<FEATURE>-<NN>`
-
-Example: `WP-001-01`, `WP-001-02` (Work Packages for Feature 001)
-
-### 2.3 State Machine for DINOForge
+### 3.2 State Machine for DINOForge
 
 DINOForge features follow this state machine:
 
@@ -97,28 +130,33 @@ CREATED → SPECIFIED → RESEARCHED → PLANNED → IMPLEMENTING → VALIDATED 
 | VALIDATED → SHIPPED | All governance checks pass; all WPs merged cleanly |
 | SHIPPED → RETROSPECTED | Post-incident analysis / lessons learned documented |
 
+### 3.3 Spec-to-Story Mapping
+
+Specifications in `docs/specs/` map to AgilePlus stories:
+
+| Spec File | AgilePlus Story | Phase |
+|----------|-----------------|-------|
+| `user-spec.md` | Core user workflows | Ongoing |
+| `technical-spec.md` | Platform architecture | Ongoing |
+| `SPEC-002-native-menu-injector.md` | F10 menu injection | Shipped |
+| `SPEC-003-prove-features-skill.md` | Prove features automation | Shipped |
+| `SPEC-005-duplicate-instance-bypass.md` | Second instance bypass | Shipped |
+
 ---
 
-## 3. Integration with Kilo Gastown
+## 4. Integration with Kilo Gastown
 
-DINOForge uses **Kilo Gastown** for multi-agent orchestration. Every AgilePlus work package becomes a **bead** (work item) in Gastown.
+### 4.1 Convoy System
 
-### 3.1 Convoy System
-
-AgilePlus work that spans multiple repositories flows through **convoys**:
+DINOForge uses **convoys** to coordinate multi-repo feature development:
 
 ```
 Feature Branch: convoy/agileplus-kilo-specs-dino/<convoy_id>/head
 ```
 
-Example from this repo:
-```
-convoy/agileplus-kilo-specs-dino/381d5195/head
-```
+Current active convoy: `convoy/agileplus-kilo-specs-dino/381d5195/head`
 
-Convoys group related work packages across repos under a single feature umbrella.
-
-### 3.2 Bead Lifecycle
+### 4.2 Bead Lifecycle
 
 Each work package (WP) becomes a **bead** in Gastown:
 
@@ -129,7 +167,7 @@ Each work package (WP) becomes a **bead** in Gastown:
 | `in_review` | VALIDATED | Work is under review |
 | `closed` | SHIPPED | Work is merged and complete |
 
-### 3.3 Polecat Agents
+### 4.3 Polecat Agents
 
 Polecat agents (e.g., `Polecat-23`) are dispatched to beads. Each polecat:
 
@@ -139,115 +177,40 @@ Polecat agents (e.g., `Polecat-23`) are dispatched to beads. Each polecat:
 4. **Commits** — pushes with descriptive messages
 5. **Calls `gt_done`** — signals completion, transitions to `in_review`
 
----
+### 4.4 Agent Role Assignments
 
-## 4. Spec Document Template
+DINOForge follows a role-based agent model documented in `AGENTS.md`:
 
-Every DINOForge spec MUST follow this template:
-
-```markdown
-# <FEATURE NAME>
-
-**Version**: X.Y.Z
-**Status**: <AGILEPLUS_STATE>
-**Last Updated**: YYYY-MM-DD
-**Spec Hash**: <SHA-256>
-**Feature ID**: SPEC-<NNN>
-**Owner**: <agent_or_developer>
+| Agent Role | Domain | File Ownership |
+|------------|--------|----------------|
+| runtime-specialist | ECS bridge, BepInEx | `src/Runtime/` |
+| sdk-architect | Registry, SDK, schemas | `src/SDK/` |
+| warfare-designer | Warfare domain, balance | `src/Domains/Warfare/` |
+| pack-builder | Content packs, YAML | `packs/` |
+| toolsmith | CLI tools, PackCompiler | `src/Tools/` |
+| qa-engineer | Tests, CI/CD | `src/Tests/`, `.github/` |
+| docs-curator | Documentation | `docs/`, `CHANGELOG.md` |
 
 ---
 
-## 1. Summary
+## 5. Development Workflows
 
-Brief description of the feature (2-4 sentences).
+### 5.1 Feature Development Flow
 
-## 2. Value Proposition
-
-Why are we building this? What problem does it solve?
-
-## 3. Actors and Users
-
-Who benefits from this feature?
-
-## 4. Functional Requirements
-
-| ID | Requirement | Priority | Acceptance Criteria |
-|----|-------------|----------|---------------------|
-| FR-001 | Description | MUST | Boolean condition |
-| FR-002 | Description | SHOULD | Boolean condition |
-
-## 5. Out of Scope
-
-What is explicitly NOT included in this feature.
-
-## 6. Assumptions and Dependencies
-
-- Assumption 1
-- Dependency on X repo
-
-## 7. Technical Approach
-
-High-level design decisions and rationale.
-
-## 8. File Impact
-
-| File/Directory | Change Type | Purpose |
-|---------------|-------------|---------|
-| src/Runtime/Plugin.cs | Modify | Reason |
-
-## 9. Work Packages
-
-| WP ID | Title | Owner | Dependencies |
-|-------|-------|-------|-------------|
-| WP-001-01 | Sub-task 1 | polecat-23 | None |
-| WP-001-02 | Sub-task 2 | polecat-24 | WP-001-01 |
-
-## 10. Success Metrics
-
-How do we measure success?
-
-## 11. Governance
-
-- Spec hash on creation: `<hash>`
-- State transitions logged in AgilePlus
-- Evidence artifacts stored in `docs/sessions/`
+```
+1. Idea → Specify (agileplus specify "feature-name")
+2. Review spec with stakeholders
+3. Research (agileplus research <id>)
+4. Plan (agileplus plan <id>)
+   → Creates WPs with dependency graph
+5. Implement WPs (agileplus implement WP01 --agent claude-code)
+6. Review (agileplus review WP01)
+7. Validate (transition to Validated state)
+8. Merge (agileplus merge <id>)
+9. Retrospect (agileplus retrospective <id>)
 ```
 
----
-
-## 5. AgilePlus Workflow Commands
-
-### 5.1 CLI Reference
-
-AgilePlus CLI (when installed via `cargo install agileplus`):
-
-| Command | Description |
-|---------|-------------|
-| `agileplus init` | Initialize AgilePlus governance in a repo |
-| `agileplus specify "Feature title"` | Create new spec via interactive interview |
-| `agileplus plan <spec-id>` | Generate work package decomposition |
-| `agileplus tasks <spec-id>` | Generate individual WP files |
-| `agileplus implement <wp-id>` | Create worktree and begin work |
-| `agileplus review <wp-id>` | Review work package |
-| `agileplus accept <spec-id>` | Accept feature (all WPs done) |
-| `agileplus merge <spec-id>` | Merge feature to main |
-
-### 5.2 DINOForge Git Integration
-
-Work is conducted in **worktrees** to keep changes isolated:
-
-```bash
-# Create feature worktree
-git worktree add ../worktrees/convoy__<feature>__<id>__gt__<agent> main
-
-# Work happens in the worktree
-cd ../worktrees/convoy__<feature>__<id>__gt__<agent>
-
-# Commit with AgilePlus context
-git commit -m "feat(WP-001-01): implement sub-task description"
-```
-
-### 5.3 Handoff Protocol
+### 5.2 Handoff Protocol
 
 When completing work, agents MUST:
 
@@ -258,18 +221,30 @@ When completing work, agents MUST:
 5. Push to remote
 6. Call `gt_done` to transition bead to `in_review`
 
+### 5.3 Integration with DINOForge Tooling
+
+AgilePlus work packages integrate with DINOForge's agent command infrastructure:
+
+| Command | Purpose | Agent |
+|---------|---------|-------|
+| `/new-pack <id> [type]` | Scaffold new content pack | pack-builder |
+| `/add-unit <pack> <id> <class>` | Add unit to pack | pack-builder |
+| `/spawn-unit <pack:unit> [x] [z]` | Test unit spawner | toolsmith |
+| `/validate` | Validate all packs | toolsmith |
+| `/test` | Run all tests | qa-engineer |
+| `/check-ci` | Run full CI locally | qa-engineer |
+
 ---
 
 ## 6. Quality Gates
 
-Before any work is considered complete, these gates MUST pass:
+Before any commit to main, DINOForge enforces quality gates:
 
 ### 6.1 Pre-Commit Gates
 
 - [ ] `dotnet build src/DINOForge.sln` — solution compiles
 - [ ] `dotnet test src/DINOForge.sln` — all tests pass (0 failures)
 - [ ] `dotnet format src/DINOForge.sln --verify-no-changes` — code formatted
-- [ ] Spec updated with new file impacts
 - [ ] CHANGELOG.md updated
 
 ### 6.2 Pre-Merge Gates (CI)
@@ -279,67 +254,20 @@ Before any work is considered complete, these gates MUST pass:
 | Build | dotnet build | Must succeed |
 | Tests | dotnet test | 0 failures |
 | Lint | dotnet format --verify-no-changes | No diff |
-| Security | CodeQL | 0 alerts |
-| Dependency Audit | trust-advisory | 0 vulnerabilities |
+| Schema Validation | PackCompiler | All packs valid |
 
 ### 6.3 Pre-Ship Gates
 
 - [ ] All WPs merged cleanly
-- [ ] Feature branch deleted
 - [ ] CHANGELOG.md entry added under correct version
-- [ ] Docs updated if public API changed
 - [ ] Spec marked as `SHIPPED`
 
 ---
 
-## 7. Governance and Audit
-
-### 7.1 Audit Trail
-
-Every state transition is recorded in an append-only JSONL audit log:
-
-```json
-{
-  "timestamp": "2026-03-31T12:00:00Z",
-  "feature_id": "SPEC-001",
-  "wp_id": "WP-001-01",
-  "transition": "IMPLEMENTING → VALIDATED",
-  "actor": "polecat-23",
-  "evidence": ["test-results.json", "lint-output.txt"],
-  "prev_hash": "abc123...",
-  "curr_hash": "def456..."
-}
-```
-
-### 7.2 Evidence Artifacts
-
-Evidence for each transition is stored in:
-
-- **Test results**: `docs/sessions/<date>-test-results/`
-- **Lint output**: `docs/sessions/<date>-lint/`
-- **Build logs**: `*.log` in repo root (existing)
-- **Research artifacts**: `docs/research/` or `docs/sessions/`
-
-### 7.3 File Ownership
-
-To prevent conflicts, DINOForge uses a **file ownership map** (see `AGENTS.md`):
-
-| Agent Role | Domain | Can Modify |
-|-----------|--------|-----------|
-| runtime-specialist | src/Runtime/ | Plugin.cs, Bridge/*, HotReload/* |
-| sdk-architect | src/SDK/ | Registry/*, Models/*, Validation/* |
-| warfare-designer | src/Domains/Warfare/ | Archetypes/*, Doctrines/*, Balance/* |
-| pack-builder | packs/ | All pack content |
-| toolsmith | src/Tools/ | PackCompiler/*, McpServer/* |
-| qa-engineer | src/Tests/ | Tests/**, workflows/* |
-| docs-curator | docs/ | docs/**, CHANGELOG.md |
-
----
-
-## 8. AgilePlus ↔ DINOForge Terminology Mapping
+## 7. AgilePlus ↔ DINOForge Terminology Mapping
 
 | AgilePlus Term | DINOForge/Gastown Equivalent |
-|----------------|------------------------------|
+|----------------|----------------------------|
 | Feature | Spec document in `docs/plans/` |
 | Work Package (WP) | Bead in Gastown rig |
 | Spec | `*_SPEC.md` file |
@@ -351,36 +279,7 @@ To prevent conflicts, DINOForge uses a **file ownership map** (see `AGENTS.md`):
 
 ---
 
-## 9. Quick Reference
-
-### 9.1 Starting a New Feature
-
-1. Create spec in `docs/plans/<FEATURE>_SPEC.md`
-2. Run `agileplus plan <spec-id>` to decompose into WPs
-3. Create beads for each WP in Gastown
-4. Dispatch polecats to beads
-
-### 9.2 Completing a Work Package
-
-1. Implement changes in worktree
-2. Run quality gates (build, test, format)
-3. Update CHANGELOG.md
-4. Commit with Co-Authored-By
-5. Push branch
-6. Call `gt_done`
-
-### 9.3 Feature Complete Checklist
-
-- [ ] All WPs merged
-- [ ] All tests pass
-- [ ] CHANGELOG.md updated
-- [ ] Spec marked SHIPPED
-- [ ] Feature branch deleted
-- [ ] Post-mortem documented (if needed)
-
----
-
-## 10. Related Documents
+## 8. Related Documents
 
 - [CLAUDE.md](./CLAUDE.md) — Core governance, build commands, architecture
 - [AGENTS.md](./AGENTS.md) — Agent roster, domain ownership, coordination


### PR DESCRIPTION
## Summary
- Added `docs/plans/AGILEPLUS_SPEC.md` documenting the AgilePlus spec-driven development methodology
- Covers 8-phase pipeline, work package decomposition, governance gates, and Kilo Gastown integration
- DINOForge-specific conventions for spec location, naming, and state machine

## Details
Created comprehensive documentation for the AgilePlus methodology as implemented in the DINOForge ecosystem:
- 8-phase pipeline (Created → Specified → Researched → Planned → Implementing → Validated → Shipped → Retrospected)
- Work package decomposition and tracking
- Integration with Kilo Gastown bead lifecycle and convoy system
- Agent role assignments and file ownership conventions
- Quality gates and handoff protocol

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that doesn’t modify runtime code or build/CI behavior. Risk is limited to potential process confusion if the new guidance conflicts with existing governance docs.
> 
> **Overview**
> Adds a new `docs/plans/AGILEPLUS_SPEC.md` that formalizes the AgilePlus spec-driven development process for this repo, including the 8-phase pipeline, work-package/branch conventions, and required quality gates.
> 
> Also documents how AgilePlus maps onto *Kilo Gastown* (convoys, bead lifecycle, `gt_done`) and codifies agent roles/file-ownership expectations to align contributions with existing governance docs like `CLAUDE.md` and `AGENTS.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a66aa2b520c5a3cab97e049d7cc58c52e42fbc6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->