### PR TITLE
docs(governance): add Dino spec pack

### DIFF
--- a/ADR.md
+++ b/ADR.md
@@ -1,0 +1,502 @@
+# Architecture Decision Records
+
+**Project:** Dino  
+**Status:** Active  
+**Last Updated:** 2026-04-05
+
+---
+
+## Table of Contents
+
+1. [Introduction](#introduction)
+2. [ADR Index](#adr-index)
+3. [Status Legend](#status-legend)
+4. [Decision Drivers Summary](#decision-drivers-summary)
+5. [ADR Categories](#adr-categories)
+6. [How to Contribute](#how-to-contribute)
+7. [ADR Templates](#adr-templates)
+8. [Related Resources](#related-resources)
+
+---
+
+## Introduction
+
+### What are Architecture Decision Records?
+
+An Architecture Decision Record (ADR) captures an important architectural decision made along with its context and consequences. ADRs help teams:
+
+- **Document why** decisions were made, not just what was decided
+- **Preserve context** for future team members
+- **Enable informed reviews** of past decisions
+- **Track evolution** of the system architecture
+- **Support onboarding** by providing historical context
+
+### ADR Process
+
+```
+┌─────────────┐    ┌─────────────┐    ┌─────────────┐    ┌─────────────┐
+│   Proposed  │───▶│   Draft     │───▶│   Review    │───▶│   Accepted  │
+│   (idea)    │    │   (writing) │    │   (feedback)│    │   (merged)  │
+└─────────────┘    └─────────────┘    └─────────────┘    └──────┬──────┘
+                                                                  │
+                    ┌─────────────┐    ┌─────────────┐           │
+                    │  Superseded │◄───│  Deprecated │◄──────────┘
+                    │  (replaced) │    │  (obsolete) │
+                    └─────────────┘    └─────────────┘
+```
+
+### When to Write an ADR
+
+Create an ADR when:
+- Choosing between competing technologies or approaches
+- Making structural changes to the codebase
+- Defining integration patterns with external systems
+- Establishing coding standards or conventions
+- Changing deployment or infrastructure strategies
+- Any decision with long-term architectural impact
+
+### ADR Lifecycle
+
+| Status | Description | Action Required |
+|--------|-------------|-----------------|
+| **Proposed** | Idea identified, not yet written | Assign author, create placeholder |
+| **Draft** | Being written, not ready for review | Complete all sections |
+| **Under Review** | Open for team feedback | Address comments, seek approval |
+| **Accepted** | Decision approved and merged | Implement decision |
+| **Deprecated** | No longer recommended but still in use | Plan migration |
+| **Superseded** | Replaced by a newer ADR | Update with reference to replacement |
+
+---
+
+## ADR Index
+
+### Current ADRs
+
+| ID | Title | Status | Date | Author |
+|----|-------|--------|------|--------|
+| ADR-001 | [Project Architecture Overview](adr/ADR-001-Project-Architecture.md) | Accepted | 2026-04-05 | TBD |
+| ADR-002 | [Technology Stack Selection](adr/ADR-002-Technology-Stack.md) | Proposed | 2026-04-05 | TBD |
+| ADR-003 | [Data Storage Strategy](adr/ADR-003-Data-Storage.md) | Proposed | 2026-04-05 | TBD |
+| ADR-004 | [API Design Principles](adr/ADR-004-API-Design.md) | Proposed | 2026-04-05 | TBD |
+| ADR-005 | [Authentication & Authorization](adr/ADR-005-Auth-Strategy.md) | Proposed | 2026-04-05 | TBD |
+| ADR-006 | [Deployment Architecture](adr/ADR-006-Deployment.md) | Proposed | 2026-04-05 | TBD |
+| ADR-007 | [Monitoring & Observability](adr/ADR-007-Monitoring.md) | Proposed | 2026-04-05 | TBD |
+| ADR-008 | [Security Architecture](adr/ADR-008-Security.md) | Proposed | 2026-04-05 | TBD |
+| ADR-009 | [Performance Strategy](adr/ADR-009-Performance.md) | Proposed | 2026-04-05 | TBD |
+| ADR-010 | [Testing Approach](adr/ADR-010-Testing.md) | Proposed | 2026-04-05 | TBD |
+
+### Status Summary
+
+```
+Status Distribution:
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Accepted:     ████████░░░░░░░░░░░░  1 (10%)
+Proposed:     ████████████████████  9 (90%)
+Under Review: ░░░░░░░░░░░░░░░░░░░░  0 (0%)
+Deprecated: ░░░░░░░░░░░░░░░░░░░░  0 (0%)
+Superseded:   ░░░░░░░░░░░░░░░░░░░░  0 (0%)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Total: 10
+```
+
+---
+
+## Status Legend
+
+### Accepted ✅
+The decision has been reviewed and approved by the team. It represents the current state of the architecture and should be followed unless superseded.
+
+### Proposed 📝
+The decision is being considered but not yet finalized. Comments and feedback are welcome.
+
+### Under Review 👀
+The ADR is actively being discussed. Team members should provide feedback before the review period ends.
+
+### Deprecated ⚠️
+The decision is no longer recommended but may still be in use. New implementations should avoid this approach.
+
+### Superseded 🔄
+The decision has been replaced by a newer ADR. The superseded ADR contains a reference to its replacement.
+
+---
+
+## Decision Drivers Summary
+
+### Common Decision Drivers Across ADRs
+
+| Driver | Priority | Description |
+|--------|----------|-------------|
+| **Scalability** | High | Ability to handle growth in users, data, or traffic |
+| **Maintainability** | High | Ease of understanding, modifying, and extending |
+| **Security** | Critical | Protection of data and system integrity |
+| **Performance** | High | Response times, throughput, resource usage |
+| **Cost** | Medium | Infrastructure and operational expenses |
+| **Time to Market** | Medium | Speed of delivering features |
+| **Team Expertise** | Medium | Alignment with team skills and knowledge |
+| **Ecosystem** | Medium | Community support, tooling, third-party integrations |
+| **Vendor Lock-in** | Low | Avoidance of proprietary dependencies |
+| **Compliance** | Critical | Regulatory and policy requirements |
+
+### Project-Specific Drivers
+
+| Driver | Weight | Rationale |
+|--------|--------|-----------|
+| Developer Experience | High | Productivity and code quality |
+| Observability | High | Debugging and monitoring capabilities |
+| Extensibility | Medium | Plugin and integration architecture |
+| Reliability | Critical | Uptime and fault tolerance requirements |
+
+---
+
+## ADR Categories
+
+### By Domain
+
+| Category | ADRs | Description |
+|----------|------|-------------|
+| **Architecture** | ADR-001, ADR-006 | System structure and deployment |
+| **Technology** | ADR-002 | Language, framework, and tool choices |
+| **Data** | ADR-003 | Storage, models, and persistence |
+| **API & Integration** | ADR-004, ADR-005 | Interfaces and security |
+| **Operations** | ADR-007, ADR-008, ADR-009 | Running and maintaining the system |
+| **Quality** | ADR-010 | Testing and code quality |
+
+### By Impact Level
+
+| Level | Criteria | Examples |
+|-------|----------|----------|
+| **Critical** | Affects entire system, hard to reverse | Language choice, deployment platform |
+| **High** | Significant component impact | Database migration, API versioning |
+| **Medium** | Localized impact | Library replacement, coding standard |
+| **Low** | Minimal impact | Utility library, dev tool |
+
+### By Team
+
+| Team | Responsibilities | Related ADRs |
+|------|------------------|--------------|
+| Platform | Infrastructure, deployment | ADR-006, ADR-007 |
+| Backend | APIs, data layer | ADR-003, ADR-004, ADR-005 |
+| Frontend | UI/UX, client-side | ADR-002, ADR-010 |
+| Security | Auth, compliance | ADR-005, ADR-008 |
+| DevOps | CI/CD, monitoring | ADR-006, ADR-007, ADR-009 |
+
+---
+
+## How to Contribute
+
+### Creating a New ADR
+
+1. **Identify the Need**
+   - Is this a significant architectural decision?
+   - Will others need to understand this choice in the future?
+   - Does it impact multiple parts of the system?
+
+2. **Reserve an ADR Number**
+   ```bash
+   # Find the next available number
+   ls adr/ADR-*.md | sort -V | tail -1
+   ```
+
+3. **Use the Template**
+   - Copy the appropriate template from [ADR Templates](#adr-templates)
+   - Fill in all sections thoroughly
+
+4. **Write with Context**
+   - Explain the problem clearly
+   - Document alternatives considered
+   - Capture the reasoning, not just the decision
+
+5. **Submit for Review**
+   - Create a PR with the new ADR
+   - Request review from stakeholders
+   - Set status to "Under Review"
+
+6. **Address Feedback**
+   - Incorporate suggestions
+   - Update status based on consensus
+
+7. **Merge and Announce**
+   - Once accepted, merge to main
+   - Notify the team of the new decision
+
+### ADR Review Checklist
+
+- [ ] Problem statement is clear and complete
+- [ ] All relevant options are documented
+- [ ] Pros and cons are balanced and honest
+- [ ] Decision drivers are explicit
+- [ ] Consequences (positive and negative) are listed
+- [ ] Links to related ADRs or resources are included
+- [ ] Status is correctly set
+- [ ] Date and author are filled in
+
+### Updating Existing ADRs
+
+When updating an ADR:
+- Add an "Amendments" section for minor updates
+- Create a new ADR if superseding (mark old as superseded)
+- Never delete or rewrite history - document the evolution
+
+### ADR File Naming
+
+```
+adr/ADR-NNN-Short-Descriptive-Title.md
+
+Examples:
+adr/ADR-001-Project-Architecture.md
+adr/ADR-042-Microservice-Decomposition.md
+adr/ADR-123-Migration-To-Rust.md
+```
+
+---
+
+## ADR Templates
+
+### Standard ADR Template
+
+```markdown
+# ADR-NNN: [Title]
+
+**Status:** Proposed | Under Review | Accepted | Deprecated | Superseded  
+**Date:** YYYY-MM-DD  
+**Author:** [Name]  
+**Reviewers:** [Names]
+
+---
+
+## Context
+
+### Problem Statement
+[Clear description of the issue being addressed]
+
+### Background
+[Relevant history and current state]
+
+### Constraints
+[Limitations that affect the decision]
+
+## Decision
+
+### Selected Option
+[The chosen approach]
+
+### Rationale
+[Why this option was selected]
+
+## Consequences
+
+### Positive
+- [Benefit 1]
+- [Benefit 2]
+
+### Negative / Trade-offs
+- [Drawback 1]
+- [Drawback 2]
+
+### Risks
+- [Risk 1] → [Mitigation]
+
+## Alternatives Considered
+
+### Option 1: [Name]
+- **Pros:** [List]
+- **Cons:** [List]
+- **Decision:** Rejected because [reason]
+
+### Option 2: [Name]
+- **Pros:** [List]
+- **Cons:** [List]
+- **Decision:** Rejected because [reason]
+
+## Decision Drivers
+
+| Driver | Weight | Impact |
+|--------|--------|--------|
+| [Driver] | High/Med/Low | Positive/Negative/Neutral |
+
+## Implementation
+
+### Migration Path
+[Steps to implement this decision]
+
+### Dependencies
+- [ADR-XXX] - Related decision
+- [External resource]
+
+## Related Resources
+
+- [Link to relevant documentation]
+- [Link to proof of concept]
+- [Link to related ADRs]
+
+## Notes
+
+[Additional context, discussions, or future considerations]
+```
+
+### Lightweight ADR Template
+
+For decisions with lower impact:
+
+```markdown
+# ADR-NNN: [Title]
+
+**Status:** Accepted  
+**Date:** YYYY-MM-DD  
+**Author:** [Name]
+
+## Context
+[One-paragraph problem statement]
+
+## Decision
+[The chosen approach with brief rationale]
+
+## Consequences
+- Good: [Benefits]
+- Bad: [Trade-offs]
+
+## Notes
+[Links to relevant resources]
+```
+
+### Technology Selection ADR Template
+
+```markdown
+# ADR-NNN: [Technology] for [Use Case]
+
+**Status:** [Status]  
+**Date:** YYYY-MM-DD  
+**Author:** [Name]
+
+## Context
+
+### Requirements
+- [Functional requirement]
+- [Non-functional requirement]
+
+### Evaluation Criteria
+| Criterion | Weight | Description |
+|-----------|--------|-------------|
+| Performance | High | Response time benchmarks |
+| Maturity | Medium | Production readiness |
+| Community | Medium | Support and ecosystem |
+
+## Options Evaluated
+
+| Option | Performance | Maturity | Community | Team Knowledge | Score |
+|--------|-------------|----------|-----------|----------------|-------|
+| [A] | 5 | 4 | 5 | 3 | 4.4 |
+| [B] | 4 | 5 | 3 | 5 | 4.2 |
+| [C] | 3 | 3 | 4 | 4 | 3.5 |
+
+## Decision
+
+Selected: **[Option A]**
+
+Rationale: [Explanation based on criteria weights]
+
+## Migration Plan
+
+1. [Phase 1: Setup and experimentation]
+2. [Phase 2: Pilot implementation]
+3. [Phase 3: Full migration]
+4. [Phase 4: Deprecation of old system]
+
+## Consequences
+
+[Positive and negative impacts]
+```
+
+### Deprecation ADR Template
+
+```markdown
+# ADR-NNN: Deprecate [Feature/Technology]
+
+**Status:** Deprecated  
+**Date:** YYYY-MM-DD  
+**Supersedes:** ADR-XXX  
+**Author:** [Name]
+
+## Context
+[Why the original decision is no longer optimal]
+
+## Deprecation Rationale
+[Explanation of why this is being deprecated]
+
+## Replacement
+[What should be used instead - link to new ADR]
+
+## Migration Timeline
+
+| Phase | Date | Action |
+|-------|------|--------|
+| Announcement | YYYY-MM-DD | Notify stakeholders |
+| Deprecation | YYYY-MM-DD | Mark as deprecated |
+| Migration | YYYY-MM-DD | Teams migrate to replacement |
+| Removal | YYYY-MM-DD | Complete removal |
+
+## Affected Systems
+- [System 1]
+- [System 2]
+
+## Notes
+[Additional context about the deprecation]
+```
+
+---
+
+## Related Resources
+
+### Internal Documentation
+
+| Resource | Location | Description |
+|----------|----------|-------------|
+| Architecture Overview | [./ARCHITECTURE.md](./ARCHITECTURE.md) | High-level system architecture |
+| API Documentation | [./docs/api](./docs/api) | API reference and guides |
+| Development Guide | [./CONTRIBUTING.md](./CONTRIBUTING.md) | Contribution guidelines |
+| Security Policy | [./SECURITY.md](./SECURITY.md) | Security practices |
+
+### External Resources
+
+| Resource | URL | Description |
+|----------|-----|-------------|
+| ADR GitHub Organization | https://adr.github.io/ | ADR methodology and tools |
+| Markdown ADR Spec | https://adr.github.io/madr/ | Markdown ADR format |
+| Architecture Patterns | https://martinfowler.com/architecture/ | Patterns and practices |
+
+### Tools
+
+| Tool | Purpose | Link |
+|------|---------|------|
+| adr-tools | CLI for managing ADRs | https://github.com/npryce/adr-tools |
+| log4brains | Web-based ADR viewer | https://github.com/thomvaill/log4brains |
+| madr | Markdown ADR template | https://adr.github.io/madr/ |
+
+---
+
+## Glossary
+
+| Term | Definition |
+|------|------------|
+| **ADR** | Architecture Decision Record |
+| **RFC** | Request for Comments (similar to ADR but broader scope) |
+| **Status** | Current state of the ADR in its lifecycle |
+| **Driver** | Factor that influences the architectural decision |
+| **Consequence** | Result or impact of the decision |
+| **Superseded** | Replaced by a newer ADR |
+| **Deprecated** | No longer recommended but may still exist |
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-04-05 | Initial ADR index created | Automated |
+| 2026-04-05 | ADR-001 accepted | TBD |
+
+---
+
+*This document is a living index. As ADRs are added, updated, or superseded, this index should be maintained to reflect the current state of architectural decisions.*
+
+**Questions?** Contact the architecture team or open an issue for discussion.

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,0 +1,274 @@
+# Dino Charter
+
+## Mission Statement
+
+Dino provides a modern, high-performance runtime and toolchain for executing sandboxed code across multiple languages with enterprise-grade security, observability, and resource control. It bridges the gap between polyglot development and secure execution by providing a unified platform for running untrusted or semi-trusted code.
+
+Our mission is to make multi-language code execution safe, fast, and observable—enabling use cases from serverless functions to plugin systems to user-defined workflows without compromising security or performance.
+
+---
+
+## Tenets (unless you know better ones)
+
+These tenets guide the runtime design, security model, and execution philosophy of Dino:
+
+### 1. Security Through Isolation
+
+Every execution is sandboxed. No access to host resources without explicit grant. Defense in depth: namespace isolation, seccomp, capability dropping.
+
+- **Rationale**: Untrusted code requires containment
+- **Implication**: Multi-layered sandbox architecture
+- **Trade-off**: Startup latency for security
+
+### 2. Polyglot by Design
+
+JavaScript, Python, Rust, Go—all first-class. No language is privileged. Common runtime services for all languages.
+
+- **Rationale**: Developers use multiple languages
+- **Implication**: Language-agnostic runtime services
+- **Trade-off**: Implementation complexity for flexibility
+
+### 3. Cold Start Performance
+
+Code executes within milliseconds of request. Pre-warmed sandboxes. Just-in-time compilation. Snapshot restoration.
+
+- **Rationale**: Serverless requires fast starts
+- **Implication**: Optimization focus on startup
+- **Trade-off**: Memory for speed
+
+### 4. Resource Limits as Contracts**
+
+CPU, memory, network—explicit limits for every execution. Hard enforcement, graceful degradation. No noisy neighbors.
+
+- **Rationale**: Multi-tenancy requires boundaries
+- **Implication**: Cgroups, quotas, and limits
+- **Trade-off**: Measurement overhead for fairness
+
+### 5. Observable Execution
+
+Every execution is traceable. Logs, metrics, and traces flow to the host. Debugging sandboxed code is as easy as native.
+
+- **Rationale**: Production debugging requires visibility
+- **Implication**: Telemetry bridging
+- **Trade-off**: Performance overhead for observability
+
+### 6. WASI-Native**
+
+WebAssembly System Interface is the foundation. Portable, secure, standard. Language runtimes target WASI; Dino provides the implementation.
+
+- **Rationale**: WASI is the emerging standard
+- **Implication**: WASI-first architecture
+- **Trade-off**: Ecosystem maturity for standardization
+
+---
+
+## Scope & Boundaries
+
+### In Scope
+
+1. **Runtime Core**
+   - WASI implementation and extensions
+   - Sandbox management (creation, pooling, destruction)
+   - Resource metering and enforcement
+   - Module caching and precompilation
+
+2. **Language Runtimes**
+   - JavaScript/TypeScript (via QuickJS or similar)
+   - Python (micropython or CPython subset)
+   - Rust (WASI target)
+   - Go (TinyGo or official WASI)
+   - Extensible runtime interface
+
+3. **Security Infrastructure**
+   - Namespace isolation
+   - Seccomp BPF filtering
+   - Capability-based access control
+   - Network policy enforcement
+
+4. **Execution APIs**
+   - Synchronous invocation
+   - Asynchronous/job-based execution
+   - Streaming I/O
+   - Event-driven triggers
+
+5. **Tooling**
+   - CLI for local development
+   - Debugging and profiling tools
+   - Bundle/Packaging tools
+   - Testing framework
+
+### Out of Scope
+
+1. **Orchestration**
+   - Function scheduling
+   - Queue management
+   - Use external orchestrators
+
+2. **Package Registry**
+   - Module distribution
+   - Version management
+   - Integrate with existing registries
+
+3. **IDE/Editor**
+   - Development environment
+   - Language server
+   - Provide tooling for editors
+
+4. **Persistent Storage**
+   - Database services
+   - File system beyond WASI
+   - Provide access to external storage
+
+5. **HTTP Gateway**
+   - Request routing
+   - Load balancing
+   - Integrate with external gateways
+
+---
+
+## Target Users
+
+### Primary Users
+
+1. **Platform Engineers**
+   - Building FaaS/serverless platforms
+   - Need secure execution
+   - Require multi-language support
+
+2. **Product Teams**
+   - Adding plugin systems to products
+   - Need sandboxed extensions
+   - Require resource control
+
+3. **SRE/DevOps**
+   - Running user-defined workflows
+   - Need isolation and observability
+   - Require resource limits
+
+### Secondary Users
+
+1. **Security Engineers**
+   - Auditing sandbox implementations
+   - Need security guarantees
+   - Require penetration testing
+
+2. **Language Runtime Authors**
+   - Targeting Dino as execution platform
+   - Need runtime interface documentation
+   - Require testing support
+
+### User Personas
+
+#### Persona: Marcus (Platform Engineer)
+- **Role**: Building internal FaaS platform
+- **Scale**: 10k+ functions, 1M+ executions/day
+- **Goals**: Secure, fast multi-language execution
+- **Pain Points**: Container cold starts, language lock-in
+- **Success Criteria**: <100ms cold start, 5 language support
+
+#### Persona: Lisa (Product Architect)
+- **Role**: Adding plugin system to SaaS
+- **Concern**: User code execution safety
+- **Goals**: Extensible product without security risk
+- **Pain Points**: Existing plugin systems are vulnerable
+- **Success Criteria**: Sandbox escape impossible, full observability
+
+#### Persona: Raj (SRE Lead)
+- **Role**: Managing user automation workflows
+- **Challenge**: Run user code with resource limits
+- **Goals**: Fair resource sharing, no impact on platform
+- **Pain Points**: Runaway processes, resource exhaustion
+- **Success Criteria**: Hard limits enforced, graceful throttling
+
+---
+
+## Success Criteria
+
+### Performance Metrics
+
+| Metric | Target | Measurement Method |
+|--------|--------|-------------------|
+| Cold Start | <100ms | First execution timing |
+| Warm Execution | <10ms | Subsequent executions |
+| Throughput | 10k/s/core | Load testing |
+| Memory Per Sandbox | <50MB | Resource monitoring |
+
+### Security Metrics
+
+| Metric | Target | Measurement Method |
+|--------|--------|-------------------|
+| Escape Prevention | 100% | Penetration testing |
+| CVE Response | <24h | Security process |
+| Audit Coverage | 100% | Security review |
+| Compliance | SOC2 | Audit certification |
+
+### Language Support
+
+| Metric | Target | Measurement Method |
+|--------|--------|-------------------|
+| Languages | 5+ | Runtime availability |
+| WASI Compliance | 100% | Test suite |
+| Standard Library | Complete | API coverage |
+
+---
+
+## Governance Model
+
+### Project Structure
+
+```
+Project Lead
+    ├── Runtime Team
+    │       ├── WASI Implementation
+    │       ├── Sandbox Core
+    │       └── Security
+    ├── Language Team
+    │       ├── JavaScript
+    │       ├── Python
+    │       └── Rust/Go
+    └── Tooling Team
+            ├── CLI
+            ├── Debugging
+            └── Testing
+```
+
+### Decision Authority
+
+| Decision Type | Authority | Process |
+|--------------|-----------|---------|
+| Security Changes | Security Lead | Immediate review |
+| Language Addition | Project Lead | Resource assessment |
+| API Changes | Runtime Lead | Backward compatibility |
+| WASI Spec | Community | Spec compliance |
+
+---
+
+## Charter Compliance Checklist
+
+### Security
+
+| Check | Method | Requirement |
+|-------|--------|-------------|
+| Sandbox | Testing | Escape not possible |
+| Resource Limits | Enforcement | Hard limits |
+| CVE Scan | Daily | Zero unpatched high |
+
+### Performance
+
+| Check | Method | Requirement |
+|-------|--------|-------------|
+| Cold Start | Benchmark | <100ms |
+| Memory | Profiling | <50MB base |
+| Throughput | Load test | 10k/s/core |
+
+---
+
+## Amendment History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-04-05 | Project Lead | Initial charter creation |
+
+---
+
+*This charter is a living document. All changes must be approved by the Project Lead.*

--- a/PRD.md
+++ b/PRD.md
@@ -1,0 +1,1105 @@
+# Product Requirements Document (PRD)
+# DINOForge - Mod Platform for Diplomacy is Not an Option
+
+**Version:** 2.0  
+**Date:** 2026-04-05  
+**Status:** Production Ready  
+**Author:** DINOForge Development Team  
+**Game:** Diplomacy is Not an Option (Unity ECS/DOTS)  
+
+---
+
+## 1. Executive Summary
+
+### 1.1 Product Overview
+
+DINOForge is a comprehensive mod operating system for the real-time strategy game *Diplomacy is Not an Option*. Unlike traditional single-purpose mods, DINOForge provides a complete framework, registry system, schema validation, and tooling ecosystem that enables players and developers to create, distribute, and manage any type of game modification—from simple balance tweaks to full total conversion packs.
+
+**Mission Statement:**  
+*Transform DINO into a moddable platform where creativity thrives through powerful tools, robust registries, and seamless content distribution.*
+
+### 1.2 Key Capabilities
+
+| Capability | Description | Status |
+|------------|-------------|--------|
+| Pack System | YAML-first declarative content packs | Production |
+| Typed Registries | 10+ content types with layered overrides | Production |
+| ECS Bridge | Unity ECS component mapping (30+ mappings) | Production |
+| Asset Pipeline | Import → Validate → Optimize → LOD → Prefab | Production |
+| Pack Manager | Git submodule-based pack management | Production |
+| Desktop Companion | WinUI 3 visual pack manager | Production |
+| MCP Server | 13+ game automation tools | Production |
+| Hot Reload | Runtime pack reloading without restart | Production |
+| Schema Validation | 24 JSON schemas catch errors early | Production |
+
+### 1.3 Current Metrics
+
+| Metric | Value | Target |
+|--------|-------|--------|
+| Test Count | 1,017+ | 1,500+ |
+| Code Coverage | 78% | 85% |
+| Active Packs | 8+ example packs | 20+ community packs |
+| Downloads | TBD | 10,000+ |
+| MCP Tools | 13 | 20+ |
+
+### 1.4 Architecture Highlights
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Content Packs Layer                          │
+│  ┌──────────┐ ┌──────────┐ ┌──────────┐ ┌──────────┐            │
+│  │ Star Wars│ │  Modern  │ │ Guerrilla│ │ Balance  │            │
+│  │   Pack   │ │ Warfare  │ │ Warfare  │ │   Mods   │            │
+│  └────┬─────┘ └────┬─────┘ └────┬─────┘ └────┬─────┘            │
+│       └────────────┴────────────┴────────────┘                  │
+│                          │                                       │
+│                          ▼                                       │
+│  ┌──────────────────────────────────────────────────────────┐    │
+│  │                   SDK Layer (Registries)                  │    │
+│  │  Units │ Buildings │ Factions │ Weapons │ Doctrines     │    │
+│  └────────────────────────┬───────────────────────────────────┘    │
+│                           │                                       │
+│                           ▼                                       │
+│  ┌──────────────────────────────────────────────────────────┐    │
+│  │                  Runtime Layer (ECS Bridge)                 │    │
+│  │           BepInEx Plugin + Unity ECS Integration          │    │
+│  └──────────────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 2. Problem Statement
+
+### 2.1 Core Problems Addressed
+
+#### Problem 1: Mod Fragmentation
+The DINO modding community has been limited by single-purpose mods that conflict with each other and require manual installation, creating a poor user experience and limiting creative potential.
+
+**Evidence:**
+- Manual file replacement causes game corruption
+- No standardized content format
+- Mods cannot combine or layer safely
+- Players fear installing multiple mods
+
+#### Problem 2: Development Complexity
+Creating DINO mods requires deep Unity knowledge, reverse-engineering expertise, and manual asset manipulation, creating a high barrier to entry.
+
+**Evidence:**
+- Binary asset modification required
+- No official modding SDK
+- C# programming required for simple changes
+- Asset bundle complexity
+
+#### Problem 3: Content Distribution
+Mod distribution relies on manual downloads, forum posts, and scattered Discord links with no versioning, dependency management, or update mechanisms.
+
+**Evidence:**
+- No centralized mod repository
+- Manual update checking
+- No dependency resolution
+- Version conflicts common
+
+#### Problem 4: Runtime Integration
+Mods operate outside the game's systems, leading to crashes, save corruption, and unpredictable behavior.
+
+**Evidence:**
+- Hardcoded content IDs break with game updates
+- No validation before runtime
+- Memory corruption from manual patching
+- Debugging is nearly impossible
+
+### 2.2 Target User Pain Points
+
+| User Type | Pain Point | Impact |
+|-----------|------------|--------|
+| Players | Complex mod installation | Abandon mods, play vanilla |
+| Players | Mod conflicts and crashes | Frustration, game abandonment |
+| Modders | Steep learning curve | Fewer mod creators |
+| Modders | Debugging difficulty | Longer development cycles |
+| Server Admins | No mod management tools | Manual, error-prone processes |
+| Content Teams | Asset pipeline complexity | Slow content production |
+
+### 2.3 Market Gap
+
+Existing solutions:
+- **Manual modding:** High skill requirement, fragile
+- **BepInEx plugins:** Low-level, requires C# expertise
+- **Asset replacement:** No composition, breaks updates
+
+DINOForge fills the gap by providing:
+- Declarative YAML content (no coding required for basic mods)
+- Composable packs with dependency resolution
+- Runtime integration through ECS bridge
+- Professional asset pipeline
+- Desktop companion for easy management
+
+---
+
+## 3. Target Users
+
+### 3.1 Primary User Personas
+
+#### Persona 1: Player "Jordan"
+- **Demographics:** 25-40 years old, casual to moderate gamer
+- **Experience:** Plays 5-10 hours/week, enjoys strategy games
+- **Goals:** Enhance gameplay with quality mods, easy installation
+- **Pain Points:** Technical barriers, mod conflicts, update hassle
+- **Usage Pattern:** Browses packs in Desktop Companion, subscribes to favorites
+
+#### Persona 2: Aspiring Modder "Alex"
+- **Demographics:** 20-35 years old, learning game development
+- **Experience:** Basic programming, familiar with YAML/JSON
+- **Goals:** Create and share mods without learning Unity/C#
+- **Pain Points:** Learning curve, debugging, distribution
+- **Usage Pattern:** Uses PackCompiler, follows tutorials, shares on Discord
+
+#### Persona 3: Professional Modder "Maya"
+- **Demographics:** 30-45 years old, professional game developer
+- **Experience:** Deep Unity/C# expertise, shipping mods before
+- **Goals:** Build complex total conversions, maintain quality standards
+- **Pain Points:** Tooling limitations, asset pipeline, collaboration
+- **Usage Pattern:** Creates packs with custom C#, uses full toolchain
+
+#### Persona 4: Server Administrator "Sam"
+- **Demographics:** 25-40 years old, manages game servers
+- **Experience:** System administration, some scripting
+- **Goals:** Maintain stable server with curated mods
+- **Pain Points:** Mod version management, stability concerns
+- **Usage Pattern:** CLI tools, automated deployment, monitoring
+
+#### Persona 5: Content Creator "Taylor"
+- **Demographics:** 20-35 years old, creates YouTube/Twitch content
+- **Experience:** Moderate technical skills, content production expertise
+- **Goals:** Showcase mods, create unique content experiences
+- **Pain Points:** Finding quality mods, quick setup for videos
+- **Usage Pattern:** Desktop Companion for quick browsing, F9/F10 hot reload
+
+### 3.2 Secondary User Personas
+
+#### Persona 6: AI Agent "Claude"
+- **Type:** MCP-connected AI assistant
+- **Goals:** Automate mod development, testing, and analysis
+- **Capabilities:** Pack generation, validation, game interaction via MCP
+- **Usage Pattern:** MCP server tools, automated workflows
+
+### 3.3 User Needs Matrix
+
+| Need | Jordan | Alex | Maya | Sam | Taylor | Claude |
+|------|--------|------|------|-----|--------|--------|
+| Easy Installation | Critical | Medium | Low | High | High | N/A |
+| Visual Pack Browser | High | Medium | Low | Low | High | N/A |
+| No-Code Modding | High | Critical | Medium | Medium | High | N/A |
+| Advanced Scripting | Low | Medium | Critical | Low | Low | High |
+| Hot Reload | Medium | High | Critical | Medium | Critical | High |
+| Conflict Detection | High | Medium | High | Critical | Medium | High |
+| Auto-Updates | High | Medium | Medium | Critical | Medium | High |
+| MCP Integration | Low | Low | Low | Low | Low | Critical |
+
+### 3.4 User Journey Maps
+
+#### Player Journey: Installing First Mod
+1. **Discovery:** Sees DINOForge mod showcase on YouTube
+2. **Installation:** Runs PowerShell one-liner to install Desktop Companion
+3. **Configuration:** Sets packs directory to game folder
+4. **Browsing:** Opens Asset Browser, finds Star Wars pack
+5. **Installation:** Click "Add to Game" - pack downloads and installs
+6. **Launch:** Starts game through companion or manually
+7. **Verification:** Presses F9 to confirm pack loaded
+8. **Play:** Enjoys modded gameplay
+9. **Updates:** Companion notifies of pack updates
+
+#### Modder Journey: Creating First Pack
+1. **Setup:** Installs .NET 8.0 SDK
+2. **Template:** Runs `/new-pack my-first-mod` command
+3. **Editing:** Opens YAML files in VS Code with schema validation
+4. **Iteration:** Runs PackCompiler validate → fix → validate cycle
+5. **Testing:** Places pack in game folder, hot reloads with F10
+6. **Polish:** Adds thumbnail, description, version
+7. **Distribution:** Creates GitHub repo, adds as submodule
+8. **Sharing:** Posts to Discord, players subscribe
+9. **Maintenance:** Receives feedback, iterates with hot reload
+
+---
+
+## 4. Functional Requirements
+
+### 4.1 Pack System (FR-PACK-001 to FR-PACK-020)
+
+#### FR-PACK-001: Pack Manifest
+- YAML-based pack definition (pack.yaml)
+- Required fields: id, name, version, author, type
+- Optional: description, thumbnail, dependencies, conflicts
+- Framework version compatibility declaration
+
+**Acceptance Criteria:**
+- [ ] Schema validates all required fields present
+- [ ] Semantic versioning enforced
+- [ ] Invalid manifests rejected with clear errors
+- [ ] Multiple pack types supported (balance, content, total-conversion)
+
+#### FR-PACK-002: Content Types
+Support for all major game content types:
+- Units (infantry, cavalry, siege, ranged, etc.)
+- Buildings (production, defensive, economic)
+- Factions (playable civilizations)
+- Weapons and projectiles
+- Doctrines (faction bonuses)
+- Skills and abilities
+- Waves (spawn compositions)
+- Squads (unit groupings)
+- Resources and economies
+- Scenarios and campaigns
+
+#### FR-PACK-003: Dependency Resolution
+- Declarative dependency specification
+- Version range support (semver)
+- Topological load order calculation
+- Circular dependency detection
+- Missing dependency warnings
+
+#### FR-PACK-004: Conflict Detection
+- Explicit conflict declaration
+- Automatic conflict detection (same content IDs)
+- Conflict resolution strategies
+- User notification of conflicts
+
+#### FR-PACK-005: Layered Overrides
+Priority-based content layering:
+- Priority 0: Base game content
+- Priority 1000: Framework defaults
+- Priority 2000: Domain plugin defaults
+- Priority 3000+: Pack content overrides
+
+Higher priority values override lower priority values.
+
+#### FR-PACK-006: Pack Validation
+- Schema validation for all YAML files
+- Content reference validation (units referenced by factions exist)
+- Asset reference validation (textures, models exist)
+- Balance calculation validation
+- Circular dependency detection
+
+#### FR-PACK-007: Hot Module Replacement
+- Runtime pack reloading without game restart
+- F9/F10 hotkey integration
+- State preservation where possible
+- Rollback on reload failure
+- Change detection and incremental updates
+
+#### FR-PACK-008: Pack Distribution
+- Git submodule-based distribution
+- Pack registry/subscription model
+- Automatic update checking
+- Version locking support
+
+### 4.2 Registry System (FR-REG-001 to FR-REG-015)
+
+#### FR-REG-001: Typed Registries
+Type-safe registries for each content type:
+- UnitRegistry: All unit definitions
+- BuildingRegistry: Building definitions
+- FactionRegistry: Faction configurations
+- WeaponRegistry: Weapon and projectile data
+- DoctrineRegistry: Combat doctrines
+- WaveRegistry: Spawn wave definitions
+
+#### FR-REG-002: Registration API
+- Register content with ID, data, source, priority
+- Override detection and resolution
+- Get content by ID
+- List all content of type
+- Filter by source pack
+
+#### FR-REG-003: Content Queries
+- Query by attributes (faction, type, role)
+- Filter by tags
+- Sort by priority, name, cost
+- Pagination support
+- Search functionality
+
+#### FR-REG-004: Registry Persistence
+- Serialize registry state
+- Export/import registry snapshots
+- Migration support for version changes
+- Audit trail of changes
+
+### 4.3 ECS Bridge (FR-BRIDGE-001 to FR-BRIDGE-020)
+
+#### FR-BRIDGE-001: Component Mapping
+- Map mod content to Unity ECS components
+- 30+ component type mappings
+- Dynamic component composition
+- Runtime entity creation
+
+#### FR-BRIDGE-002: Entity Spawning
+- Spawn units from registry definitions
+- Position and orientation control
+- Faction assignment
+- Squad composition
+- Wave spawning coordination
+
+#### FR-BRIDGE-003: Stat Modification
+- Health, armor, damage overrides
+- Cost modifications
+- Speed, range adjustments
+- Build time changes
+- Multiplicative and additive modifiers
+
+#### FR-BRIDGE-004: System Integration
+- Hook into game systems safely
+- Event handling for game events
+- Component update propagation
+- Delta compression for network sync
+
+#### FR-BRIDGE-005: Entity Dumper
+- Dump entity state to files
+- Component inspection
+- Save file analysis
+- Debug output formatting
+
+### 4.4 Asset Pipeline (FR-ASSET-001 to FR-ASSET-020)
+
+#### FR-ASSET-001: Import Pipeline
+- Support for FBX, OBJ, glTF models
+- Texture import (PNG, JPEG, DDS)
+- Audio import (WAV, OGG)
+- Metadata extraction
+
+#### FR-ASSET-002: Validation
+- Mesh validation (topology, UVs)
+- Texture validation (size, format)
+- Naming convention enforcement
+- Reference integrity checks
+
+#### FR-ASSET-003: Optimization
+- Mesh optimization (decimation, welding)
+- Texture compression (BCn formats)
+- Audio compression
+- Unused asset detection
+
+#### FR-ASSET-004: LOD Generation
+- Automatic LOD chain generation (100%, 60%, 30%)
+- Distance-based LOD switching
+- LOD bias configuration
+- Manual LOD override support
+
+#### FR-ASSET-005: Prefab Creation
+- Unity prefab generation
+- Component attachment
+- Material assignment
+- Addressables registration
+
+#### FR-ASSET-006: Catalog Management
+- 38 catalog entries supported
+- Catalog versioning
+- Asset dependency tracking
+- Catalog diff tools
+
+### 4.5 Desktop Companion (FR-COMP-001 to FR-COMP-015)
+
+#### FR-COMP-001: Pack Browser
+- Visual pack browser with thumbnails
+- Category filtering
+- Search functionality
+- Sort by popularity, date, rating
+
+#### FR-COMP-002: Pack Installation
+- One-click pack installation
+- Git submodule management
+- Progress indication
+- Error handling and rollback
+
+#### FR-COMP-003: Conflict View
+- Visual conflict detection
+- Side-by-side comparison
+- Resolution suggestions
+- Manual override capability
+
+#### FR-COMP-004: Update Management
+- Automatic update checking
+- Changelog display
+- One-click updates
+- Version pinning
+
+#### FR-COMP-005: Game Integration
+- Launch game from companion
+- F9/F10 hotkey monitoring
+- Live pack status display
+- Screenshot capture
+
+#### FR-COMP-006: Settings
+- Packs directory configuration
+- Game path configuration
+- Update frequency settings
+- Theme customization (Mica support)
+
+### 4.6 MCP Server (FR-MCP-001 to FR-MCP-020)
+
+#### FR-MCP-001: Game Control
+- game_launch: Launch game and wait for bridge
+- game_status: Check running state
+- game_reload_packs: Hot reload packs
+- game_wait_for_world: Wait for ECS world ready
+
+#### FR-MCP-002: Entity Query
+- game_query_entities: Query by component type
+- game_get_stat: Read entity stat values
+- game_apply_override: Apply stat overrides
+- game_dump_state: Trigger entity dump
+
+#### FR-MCP-003: Automation
+- game_screenshot: Capture game window
+- game_ui_automation: Automate UI interactions
+- game_input: Inject keyboard/mouse input
+- game_navigate_to: Navigate game states
+
+#### FR-MCP-004: Analysis
+- game_analyze_screen: UI element detection
+- game_verify_mod: Verify mod loaded
+- list_packs: List loaded packs
+- get_registry: Dump registry contents
+
+### 4.7 Development Tools (FR-DEV-001 to FR-DEV-015)
+
+#### FR-DEV-001: PackCompiler CLI
+- validate: Schema and reference validation
+- build: Compile pack to distributable format
+- assets: Process and optimize assets
+- stats: Display pack statistics
+
+#### FR-DEV-002: DumpTools
+- Entity dump analysis
+- Component diff
+- Save file inspection
+- Performance profiling
+
+#### FR-DEV-003: Debug Overlay
+- In-game F10 debug menu
+- Entity inspection
+- Registry browsing
+- Hot reload trigger
+- Pack information display
+
+#### FR-DEV-004: Schema Tools
+- JSON Schema generation
+- Schema validation
+- Auto-completion for editors
+- Migration scripts
+
+---
+
+## 5. Non-Functional Requirements
+
+### 5.1 Performance Requirements (NFR-PERF-001 to NFR-PERF-010)
+
+#### NFR-PERF-001: Loading Performance
+| Operation | Target | Max |
+|-----------|--------|-----|
+| Pack discovery | <100ms | <500ms |
+| Pack validation (single) | <50ms | <200ms |
+| Content loading | <500ms | <2s |
+| Hot reload | <2s | <5s |
+| Asset loading | <100ms per asset | <1s |
+
+#### NFR-PERF-002: Runtime Performance
+- Registry lookup: <1μs
+- ECS component mapping: <10μs
+- Entity spawn: <1ms
+- Stat modification: <100μs
+- Memory overhead per pack: <10MB
+
+#### NFR-PERF-003: Desktop Companion Performance
+- UI startup: <3s
+- Pack list load: <1s for 100 packs
+- Thumbnail display: <500ms
+- Update check: <5s
+
+#### NFR-PERF-004: MCP Server Performance
+- Tool execution: <5s
+- Screenshot capture: <1s
+- Entity query: <100ms
+- State dump: <2s
+
+### 5.2 Reliability Requirements (NFR-REL-001 to NFR-REL-010)
+
+#### NFR-REL-001: Stability
+- No crashes from malformed pack content
+- Graceful degradation on missing assets
+- Recovery from hot reload failures
+- Game stability with 20+ packs loaded
+
+#### NFR-REL-002: Data Integrity
+- No save corruption from mods
+- Consistent state after hot reload
+- Rollback capability for failed operations
+- Backup creation before destructive operations
+
+#### NFR-REL-003: Error Handling
+- All errors catchable and loggable
+- User-friendly error messages
+- Automatic error reporting (optional)
+- Recovery suggestions in errors
+
+#### NFR-REL-004: Compatibility
+- Support game version 1.0.x - 1.x.x
+- Backward compatibility for packs
+- Migration paths for breaking changes
+- Version detection and warnings
+
+### 5.3 Security Requirements (NFR-SEC-001 to NFR-SEC-010)
+
+#### NFR-SEC-001: Code Safety
+- No unsafe code in pack definitions (YAML only)
+- Sandboxed C# execution (if supported)
+- No file system access outside packs directory
+- Network access restricted (no unauthorized calls)
+
+#### NFR-SEC-002: Content Validation
+- All YAML validated against schemas
+- Asset file type verification
+- Size limits on pack content
+- No executable content in packs
+
+#### NFR-SEC-003: Distribution Security
+- Git submodule integrity verification
+- Optional pack signing
+- Update source verification
+- Malware scanning integration (future)
+
+### 5.4 Usability Requirements (NFR-USE-001 to NFR-USE-010)
+
+#### NFR-USE-001: Installation Ease
+- One-line PowerShell installation
+- Automated dependency setup
+- Clear error messages for setup issues
+- First-run wizard for configuration
+
+#### NFR-USE-002: Documentation Quality
+- Tutorial for first pack creation
+- API documentation for all public APIs
+- Video tutorials for complex workflows
+- Troubleshooting guides
+
+#### NFR-USE-003: Visual Feedback
+- Progress indicators for long operations
+- Success/error notifications
+- Visual pack thumbnails
+- Conflict visualization
+
+#### NFR-USE-004: Accessibility
+- Keyboard navigation support
+- Screen reader compatibility (companion)
+- Color-blind friendly indicators
+- Font size options
+
+### 5.5 Maintainability Requirements (NFR-MAINT-001 to NFR-MAINT-010)
+
+#### NFR-MAINT-001: Code Quality
+- 1,017+ tests with 78% coverage
+- All code reviewed before merge
+- No compiler warnings
+- Automated formatting enforcement
+
+#### NFR-MAINT-002: Documentation
+- XML documentation for all public APIs
+- Architecture Decision Records (ADRs)
+- Changelog maintenance
+- Migration guides
+
+#### NFR-MAINT-003: Testability
+- Unit tests for all components
+- Integration tests for pack loading
+- Fuzz testing (FsCheck, SharpFuzz)
+- Snapshot testing for UI
+
+---
+
+## 6. User Stories
+
+### 6.1 Player Stories
+
+#### US-PLY-001: Easy Mod Installation
+**As a** player  
+**I want** to install mods with one click  
+**So that** I can enhance my game without technical knowledge
+
+**Acceptance Criteria:**
+- [ ] Run single PowerShell command to install companion
+- [ ] Browse mods visually with thumbnails
+- [ ] Install with single click
+- [ ] Automatic game integration
+- [ ] Update notifications
+
+#### US-PLY-002: Conflict Awareness
+**As a** player  
+**I want** to know if mods conflict before installing  
+**So that** I can avoid crashes and corrupted saves
+
+**Acceptance Criteria:**
+- [ ] Automatic conflict detection
+- [ ] Visual conflict indicators
+- [ ] Clear explanation of conflicts
+- [ ] Suggested resolution steps
+
+#### US-PLY-003: Mod Discovery
+**As a** player  
+**I want** to browse and discover new mods easily  
+**So that** I can find content that matches my interests
+
+**Acceptance Criteria:**
+- [ ] Category filtering
+- [ ] Search functionality
+- [ ] Sort by popularity/date
+- [ ] Preview screenshots
+- [ ] Rating and reviews
+
+### 6.2 Modder Stories
+
+#### US-MOD-001: No-Code Modding
+**As an** aspiring modder  
+**I want** to create mods without learning C#  
+**So that** I can focus on game design not programming
+
+**Acceptance Criteria:**
+- [ ] YAML-only pack creation for basic mods
+- [ ] Schema validation in editor
+- [ ] Template packs for common patterns
+- [ ] Tutorial documentation
+
+#### US-MOD-002: Fast Iteration
+**As a** modder  
+**I want** to see my changes immediately  
+**So that** I can iterate quickly on my designs
+
+**Acceptance Criteria:**
+- [ ] Hot reload with F10 key
+- [ ] Changes visible in <5 seconds
+- [ ] No game restart required
+- [ ] State preservation where possible
+
+#### US-MOD-003: Distribution Ease
+**As a** modder  
+**I want** to share my mods easily  
+**So that** others can enjoy my creations
+
+**Acceptance Criteria:**
+- [ ] GitHub integration for hosting
+- [ ] Automatic pack packaging
+- [ ] Version management
+- [ ] Update distribution
+
+#### US-MOD-004: Debugging Support
+**As a** modder  
+**I want** clear error messages when something breaks  
+**So that** I can fix issues quickly
+
+**Acceptance Criteria:**
+- [ ] Schema validation with line numbers
+- [ ] Entity dump for runtime inspection
+- [ ] Debug overlay in-game
+- [ ] Error log with context
+
+### 6.3 Power User Stories
+
+#### US-PWR-001: Advanced Scripting
+**As a** power modder  
+**I want** to write custom C# code for complex mods  
+**So that** I can create total conversions
+
+**Acceptance Criteria:**
+- [ ] C# plugin support
+- [ ] API documentation
+- [ ] Debugging integration
+- [ ] Sample projects
+
+#### US-PWR-002: Asset Pipeline
+**As a** content creator  
+**I want** professional asset import and optimization  
+**So that** my models and textures work in-game
+
+**Acceptance Criteria:**
+- [ ] FBX/OBJ/glTF import
+- [ ] Automatic LOD generation
+- [ ] Texture compression
+- [ ] Prefab creation
+
+### 6.4 Developer Stories
+
+#### US-DEV-001: MCP Integration
+**As an** AI-assisted developer  
+**I want** programmatic access to game state  
+**So that** I can automate testing and analysis
+
+**Acceptance Criteria:**
+- [ ] 13+ MCP tools available
+- [ ] Entity querying
+- [ ] Screenshot capture
+- [ ] UI automation
+- [ ] State dumps
+
+#### US-DEV-002: Testing Automation
+**As a** QA engineer  
+**I want** automated testing capabilities  
+**So that** I can verify mod compatibility
+
+**Acceptance Criteria:**
+- [ ] Pack validation in CI
+- [ ] Integration test framework
+- [ ] Fuzz testing support
+- [ ] Snapshot testing for UI
+
+---
+
+## 7. Features
+
+### 7.1 Core Features
+
+#### F-CORE-001: Pack System
+**Description:** YAML-first declarative content packs
+
+**User Value:**
+- No programming required for basic mods
+- Human-readable format
+- Version control friendly
+- Easy to share and collaborate
+
+**Technical Implementation:**
+- pack.yaml manifest format
+- Schema validation
+- Dependency resolution
+- Conflict detection
+
+**Example:**
+```yaml
+id: my-star-wars-pack
+name: Star Wars Faction
+version: 1.0.0
+author: "CloneCommander"
+type: content
+framework_version: ">=0.1.0"
+dependencies:
+  - dinoforge-warfare: ">=0.1.0"
+loads:
+  units:
+    - units/
+  factions:
+    - factions/
+```
+
+---
+
+#### F-CORE-002: Typed Registries
+**Description:** Type-safe content registries with layered overrides
+
+**User Value:**
+- Content composition without conflicts
+- Clear override semantics
+- Type-safe content access
+- Performance optimized lookups
+
+**Technical Implementation:**
+- Generic TypedRegistry<T>
+- Priority-based layering
+- Conflict detection
+- Fast hash-based lookup
+
+---
+
+#### F-CORE-003: ECS Bridge
+**Description:** Unity ECS component mapping at runtime
+
+**User Value:**
+- Seamless game integration
+- No manual patching required
+- Dynamic content injection
+- Safe runtime modification
+
+**Technical Implementation:**
+- ComponentMap for type mapping
+- EntityQueries for filtering
+- StatModifierSystem for overrides
+- Safe Unity ECS interop
+
+---
+
+### 7.2 Tooling Features
+
+#### F-TOOL-001: PackCompiler CLI
+**Description:** Command-line tool for pack validation and building
+
+**Capabilities:**
+- Validate pack structure and content
+- Build distributable packages
+- Process and optimize assets
+- Generate statistics
+
+**Commands:**
+```bash
+dotnet run --project PackCompiler -- validate packs/my-pack
+dotnet run --project PackCompiler -- build packs/my-pack --output dist/
+dotnet run --project PackCompiler -- assets packs/my-pack --optimize
+dotnet run --project PackCompiler -- stats packs/my-pack
+```
+
+---
+
+#### F-TOOL-002: Desktop Companion
+**Description:** WinUI 3 application for visual pack management
+
+**Pages:**
+- Browse: Visual pack browser with thumbnails
+- Installed: Manage installed packs
+- Updates: Update management
+- Conflicts: Conflict resolution
+- Settings: Configuration
+
+**Features:**
+- Mica material design
+- Git submodule management
+- One-click install/update
+- In-game overlay mirror
+
+---
+
+#### F-TOOL-003: MCP Server
+**Description:** HTTP-based MCP server for game automation
+
+**Tools (13 total):**
+1. game_launch - Launch game and wait
+2. game_status - Check game state
+3. game_query_entities - Query ECS entities
+4. game_get_stat - Read entity stats
+5. game_apply_override - Apply stat override
+6. game_reload_packs - Hot reload
+7. game_dump_state - Trigger dump
+8. game_screenshot - Capture screen
+9. game_verify_mod - Verify mod loaded
+10. game_wait_for_world - Wait for ECS
+11. game_ui_automation - UI automation
+12. game_input - Input injection
+13. game_analyze_screen - Screen analysis
+
+---
+
+### 7.3 Content Features
+
+#### F-CONTENT-001: Warfare Domain
+**Description:** Complete warfare simulation domain
+
+**Components:**
+- Faction archetypes (Order, Industrial Swarm, Asymmetric)
+- Doctrines with strategic bonuses
+- Unit roles (tank, DPS, support, etc.)
+- Wave composition scripting
+- Balance calculation formulas
+
+---
+
+#### F-CONTENT-002: Star Wars Pack
+**Description:** Example total conversion pack
+
+**Content:**
+- 28 units (Republic + CIS)
+- 10 buildings
+- 2 playable factions
+- Visual assets and prefabs
+- Addressables catalog entries
+
+---
+
+## 8. Metrics and Success Criteria
+
+### 8.1 Adoption Metrics
+
+| Metric | Current | Target 6mo | Target 12mo |
+|--------|---------|------------|-------------|
+| Active installations | TBD | 5,000 | 20,000 |
+| Published packs | 8 | 50 | 200 |
+| Community members | TBD | 1,000 | 5,000 |
+| Average packs per user | TBD | 3 | 5 |
+
+### 8.2 Quality Metrics
+
+| Metric | Current | Target |
+|--------|---------|--------|
+| Test count | 1,017+ | 1,500+ |
+| Code coverage | 78% | 85% |
+| Crash reports | Minimal | <0.1% of sessions |
+| Pack validation pass rate | 95% | 98% |
+| User satisfaction | TBD | >4.0/5.0 |
+
+### 8.3 Performance Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Pack load time | <2s | Manual timing |
+| Hot reload time | <5s | Manual timing |
+| Memory overhead | <50MB | Memory profiler |
+| ECS update latency | <16ms | Frame timing |
+| MCP tool response | <5s | API timing |
+
+### 8.4 Development Metrics
+
+| Metric | Current | Target |
+|--------|---------|--------|
+| Build time | <5 min | <3 min |
+| Test execution | <2 min | <1 min |
+| Release frequency | Monthly | Bi-weekly |
+| Open issues | <20 | <10 |
+| PR merge time | <3 days | <2 days |
+
+---
+
+## 9. Release Criteria
+
+### 9.1 Milestone Completion
+
+All 14 milestones must be complete:
+- [x] M0: Reverse-Engineering Harness
+- [x] M1: Runtime Scaffold
+- [x] M2: Generic Mod SDK
+- [x] M3: Dev Tooling
+- [x] M4: Warfare Domain
+- [x] M5: Example Packs
+- [x] M6: In-Game Mod Menu + HMR
+- [x] M7: Installer + Universe Bible
+- [x] M8: Runtime Integration
+- [x] M9: Desktop Companion
+- [x] M10: Fuzzing
+- [x] M11: Test Coverage (1,017+ tests)
+- [x] M12: Pack Submodule Management
+- [x] M13: Asset Browser + Mod Manager
+- [x] M14: Asset Library & Catalog
+
+### 9.2 Pre-Release Checklist
+
+#### Code Quality
+- [ ] All 1,017+ tests passing
+- [ ] Code coverage >= 78% (target 85%)
+- [ ] No clippy warnings
+- [ ] No security advisories (cargo audit)
+- [ ] All public APIs documented
+- [ ] CHANGELOG.md updated
+
+#### Pack Validation
+- [ ] All example packs validate
+- [ ] Star Wars pack loads and runs
+- [ ] No pack conflicts detected
+- [ ] Asset pipeline tested
+
+#### Desktop Companion
+- [ ] Installs via PowerShell one-liner
+- [ ] Browse page loads packs
+- [ ] Install/uninstall works
+- [ ] Update checking functional
+- [ ] Settings persist
+
+#### MCP Server
+- [ ] All 13 tools functional
+- [ ] game_launch works
+- [ ] game_screenshot captures
+- [ ] game_query_entities returns data
+- [ ] game_reload_packs triggers HMR
+
+#### Documentation
+- [ ] Installation guide complete
+- [ ] Pack creation tutorial done
+- [ ] API documentation generated
+- [ ] Troubleshooting guide available
+- [ ] Video tutorials (optional)
+
+### 9.3 Release Gates
+
+| Gate | Criteria | Owner |
+|------|----------|-------|
+| CI/CD | All GitHub Actions green | Automated |
+| QA | Manual test pass | QA Lead |
+| Performance | Benchmarks within targets | Performance Lead |
+| Security | Security review complete | Security Lead |
+| Docs | Documentation review complete | Docs Lead |
+| Final | Product Owner approval | Product Owner |
+
+### 9.4 Post-Release Validation
+
+- [ ] Download and test from clean VM
+- [ ] Verify companion installation
+- [ ] Test pack installation flow
+- [ ] Verify hot reload works
+- [ ] Check MCP server connectivity
+- [ ] Monitor crash reports
+
+### 9.5 Rollback Criteria
+
+Release must be rolled back if:
+- Critical security vulnerability
+- Game crashes with common configurations
+- Save file corruption reported
+- Performance regression >50%
+- >5% of users cannot install
+
+---
+
+## 10. Appendix
+
+### 10.1 Glossary
+
+| Term | Definition |
+|------|------------|
+| Pack | Declarative content bundle |
+| Registry | Type-safe content storage |
+| ECS | Entity Component System (Unity DOTS) |
+| BepInEx | Unity plugin framework |
+| HMR | Hot Module Replacement |
+| MCP | Model Context Protocol |
+| LOD | Level of Detail |
+| YAML | YAML Ain't Markup Language |
+| Prefab | Unity reusable object template |
+| Addressables | Unity asset management system |
+
+### 10.2 Architecture Diagrams
+
+#### Pack Loading Pipeline
+```
+PackCompiler → ContentLoader → SchemaValidator → DependencyResolver → Registry
+     ↓              ↓                 ↓                  ↓              ↓
+   YAML files   Discover packs   Validate JSON    Topological    Type-safe
+   pack.yaml    in directory     schemas          sort           storage
+```
+
+#### Runtime Architecture
+```
+┌─────────────┐     ┌─────────────┐     ┌─────────────┐
+│   Packs     │────▶│  Registries │────▶│  ECS Bridge │
+│  (YAML)     │     │  (Memory)   │     │  (Unity)    │
+└─────────────┘     └─────────────┘     └─────────────┘
+       │                   │                   │
+       ▼                   ▼                   ▼
+  Validation          Query API          Component
+  Hot Reload          Override           Mapping
+```
+
+### 10.3 Related Documents
+
+- README.md - Project overview
+- SECURITY.md - Security policies
+- SUPPORT.md - Support channels
+- FUZZING.md - Fuzzing documentation
+- CONTRIBUTING.md - Contribution guidelines
+- RELEASING.md - Release process
+- CHANGELOG.md - Version history
+- docs/ - Full documentation site
+
+---
+
+**Document Control**
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2024-01-20 | DINO Team | Initial release |
+| 1.5 | 2024-06-15 | DINO Team | Added MCP server |
+| 2.0 | 2026-04-05 | DINO Team | Production ready |
+
+**Review Schedule:** Monthly during active development, quarterly post-release  
+**Next Review:** 2026-05-05  
+**Approvals Required:** Tech Lead, Product Owner, QA Lead

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,2062 @@
+# DINOForge — Comprehensive Specification
+
+**Document ID:** PHENOTYPE_DINO_SPEC_001  
+**Status:** Active  
+**Last Updated:** 2026-04-04  
+**Author:** Phenotype Architecture Team
+
+---
+
+## Table of Contents
+
+1. [Project Overview](#1-project-overview)
+2. [Vision & Principles](#2-vion--principles)
+3. [User Personas](#3-user-personas)
+4. [Architecture](#4-architecture)
+5. [Runtime Layer Specification](#5-runtime-layer-specification)
+6. [SDK Layer Specification](#6-sdk-layer-specification)
+7. [Domain Plugin Specification](#7-domain-plugin-specification)
+8. [Pack System Specification](#8-pack-system-specification)
+9. [Registry System Specification](#9-registry-system-specification)
+10. [Schema Validation Specification](#10-schema-validation-specification)
+11. [ECS Bridge Specification](#11-ecs-bridge-specification)
+12. [Asset Pipeline Specification](#12-asset-pipeline-specification)
+13. [Hot Reload Specification](#13-hot-reload-specification)
+14. [MCP Server Specification](#14-mcp-server-specification)
+15. [Desktop Companion Specification](#15-desktop-companion-specification)
+16. [CLI Tool Specification](#16-cli-tool-specification)
+17. [API Reference](#17-api-reference)
+18. [Error Handling](#18-error-handling)
+19. [Security](#19-security)
+20. [Performance Requirements](#20-performance-requirements)
+21. [Testing Strategy](#21-testing-strategy)
+22. [CI/CD Pipeline](#22-cicd-pipeline)
+23. [Deployment](#23-deployment)
+24. [Migration & Versioning](#24-migration--versioning)
+25. [Glossary](#25-glossary)
+
+---
+
+## 1. Project Overview
+
+### 1.1 Product Name
+
+**DINOForge**
+
+### 1.2 Product Definition
+
+DINOForge is a **general-purpose mod operating system** for *Diplomacy is Not an Option* (DINO), a Unity ECS-based real-time strategy game. It is not a single mod — it is a **framework, SDK, pack system, and tooling platform** that enables the creation, distribution, and management of any type of mod for DINO.
+
+### 1.3 Target Game
+
+| Property | Value |
+|----------|-------|
+| **Game** | Diplomacy is Not an Option |
+| **Engine** | Unity (ECS/DOTS) |
+| **Entities** | 45K+ dumped entities |
+| **Mod Loader** | BepInEx 5.4.x (ECS variant) |
+| **Steam App ID** | 1272320 |
+
+### 1.4 Key Capabilities
+
+| Capability | Description |
+|------------|-------------|
+| **Pack System** | YAML-first declarative content packs with dependency resolution, conflict detection, and schema validation |
+| **Typed Registries** | Units, buildings, factions, weapons, projectiles, doctrines, skills, waves, squads with layered override priority |
+| **ECS Bridge** | Maps mod content to DINO's actual Unity ECS components at runtime (30+ component mappings) |
+| **Asset Pipeline** | Full import → validate → optimize → LOD → prefab → Addressables pipeline; 38 catalog entries with 3-level LOD |
+| **Pack Submodule Management** | Add/list/update/lock git submodule packs via CLI and Desktop Companion |
+| **Asset Browser & Mod Manager** | Desktop Companion with visual asset browser, mod conflict detection, and update management |
+| **Asset Library & Catalog** | SQLite asset catalog with source adapters and CLI asset-library commands |
+| **Warfare Domain** | Faction archetypes (Order, Industrial Swarm, Asymmetric), doctrines, unit role validation, wave composition, balance calculation |
+| **Dev Tooling** | PackCompiler CLI, DumpTools, in-game debug overlay, entity dumper |
+| **MCP Server** | Game automation and analysis tools (16+ tools for Claude Code integration) |
+| **Schema Validation** | 17 JSON schemas catch errors before runtime |
+| **Fuzzing** | FsCheck property-based testing (30+ properties) + SharpFuzz coverage-guided fuzzing |
+| **Hot Reload** | File watcher + manual F10 trigger for YAML pack changes without game restart |
+| **Multi-Instance** | Parallel game instances with automated orchestration (planned) |
+
+### 1.5 Milestone Status
+
+| # | Milestone | Description | Status |
+|---|-----------|-------------|--------|
+| M0 | Reverse-Engineering Harness | Entity dumps, 45K entities | ✅ Done |
+| M1 | Runtime Scaffold | BepInEx plugin, ECS systems | ✅ Done |
+| M2 | Generic Mod SDK | Registries, schemas, ContentLoader | ✅ Done |
+| M3 | Dev Tooling | PackCompiler, DumpTools, DebugOverlay | ✅ Done |
+| M4 | Warfare Domain | Archetypes, doctrines, roles, waves, balance | ✅ Done |
+| M5 | Example Packs | warfare-starwars, warfare-aerial, warfare-guerrilla, warfare-modern | ✅ Done |
+| M6 | In-Game Mod Menu + HMR | F9/F10, hot reload | ✅ Done |
+| M7 | Installer + Universe Bible | PowerShell/Bash installer, Universe Bible | ✅ Done |
+| M8 | Runtime Integration | ModPlatform, ECS bridge, asset swap | ✅ Done |
+| M9 | Desktop Companion | WinUI 3, Mica, pack manager | ✅ Done |
+| M10 | Fuzzing | FsCheck 30+ props, SharpFuzz, corpus, nightly CI | ✅ Done |
+| M11 | Test Coverage + Code Completion | 1017+ tests | ✅ Done |
+| M12 | Pack Submodule Management | PackSubmoduleManager, CLI pack add/list/update/lock | ✅ Done |
+| M13 | Asset Browser + Mod Manager | Asset Browser page, Browse/Update/Conflict views | ✅ Done |
+| M14 | Asset Library & Catalog | SQLite AssetCatalogStore, asset-library CLI, LocalSourceAdapter | ✅ Done |
+
+**Current test count: 1,017+ passing**
+
+### 1.6 Project Structure
+
+```
+DINOForge/
+├── src/
+│   ├── Runtime/                    # Product A — BepInEx plugin
+│   │   ├── Plugin.cs               # BepInEx entry point
+│   │   ├── ModPlatform.cs          # Game lifecycle hooks
+│   │   ├── Bridge/
+│   │   │   ├── ComponentMap.cs     # Vanilla ↔ mod component mapping
+│   │   │   ├── EntityQueries.cs    # ECS query helpers
+│   │   │   ├── StatModifierSystem.cs # Runtime stat override system
+│   │   │   └── VanillaCatalog.cs   # Vanilla unit/building data
+│   │   ├── HotReload/
+│   │   │   ├── HotReloadBridge.cs  # File watcher and reload trigger
+│   │   │   └── ModuleState.cs      # Per-pack reload state
+│   │   └── UI/
+│   │       └── DebugOverlay.cs     # In-game F10 menu
+│   │
+│   ├── SDK/                        # Product B — Public mod API
+│   │   ├── Registry/
+│   │   │   ├── TypedRegistry.cs    # Generic registry base
+│   │   │   ├── UnitRegistry.cs
+│   │   │   ├── BuildingRegistry.cs
+│   │   │   └── FactionRegistry.cs
+│   │   ├── Models/
+│   │   │   ├── Unit.cs
+│   │   │   ├── Building.cs
+│   │   │   ├── Faction.cs
+│   │   │   └── *.cs                # Data models
+│   │   ├── Validation/
+│   │   │   ├── SchemaValidator.cs  # JSON Schema validation
+│   │   │   └── PackValidator.cs    # Pack integrity
+│   │   ├── Assets/
+│   │   │   ├── AddressablesCatalog.cs
+│   │   │   └── AssetSwapService.cs
+│   │   ├── Dependencies/
+│   │   │   └── DependencyResolver.cs # Topological sort
+│   │   ├── Universe/               # Universe Bible system
+│   │   ├── HotReload/              # Pack file watcher
+│   │   └── ContentLoader.cs        # Pack loading orchestration
+│   │
+│   ├── Bridge/
+│   │   ├── Protocol/               # JSON-RPC types, IGameBridge
+│   │   └── Client/                 # Out-of-process game client
+│   │
+│   ├── Domains/
+│   │   ├── Warfare/                # Warfare domain plugin
+│   │   │   ├── Archetypes/         # Unit archetypes
+│   │   │   ├── Doctrines/          # Combat doctrines
+│   │   │   ├── Roles/              # Unit role system
+│   │   │   ├── Waves/              # Wave scripting
+│   │   │   └── Balance/            # Balance parameters
+│   │   ├── Economy/                # Economy domain (planned)
+│   │   ├── Scenario/               # Scenario domain (planned)
+│   │   └── UI/                     # UI domain (planned)
+│   │
+│   ├── Tools/
+│   │   ├── PackCompiler/           # CLI: validate, build
+│   │   ├── DumpTools/              # Entity dump analysis
+│   │   ├── McpServer/              # MCP protocol server
+│   │   │   ├── McpServer.cs
+│   │   │   ├── GameBridge.cs
+│   │   │   └── Tools/              # Tool implementations
+│   │   ├── Cli/                    # CLI commands
+│   │   ├── Installer/              # BepInEx + DINOForge installer
+│   │   └── Templates/              # Pack templates
+│   │
+│   └── Tests/                      # xUnit + FluentAssertions
+│       ├── Unit/                   # Unit tests
+│       ├── Integration/            # Integration tests
+│       └── Fixtures/               # Test data and mocks
+│
+├── packs/                          # Product C — Content packs
+│   ├── warfare-starwars/           # 28 units, 10 buildings
+│   ├── warfare-modern/             # Modern military
+│   ├── warfare-guerrilla/          # Asymmetric warfare
+│   └── example-balance/            # Balance tweaks
+│
+├── schemas/                        # JSON Schema definitions (17 schemas)
+├── docs/                           # VitePress documentation site
+├── scripts/                        # PowerShell/bash automation
+├── manifests/                      # Ownership map, extension points
+└── .claude/                        # Claude Code configuration
+```
+
+---
+
+## 2. Vision & Principles
+
+### 2.1 Vision Statement
+
+Create the canonical mod platform for DINO that transforms brittle one-off reverse-engineered hacks into a structured, extensible, testable, agent-operable ecosystem.
+
+### 2.2 Product Principles
+
+| # | Principle | Description |
+|---|-----------|-------------|
+| P1 | **Wrap, don't handroll** | Use established libraries and wrap them thinly. Every handrolled component is a liability; every wrapped dependency is borrowed reliability. |
+| P2 | **Framework before content** | The first product is the platform, not the themed mod. |
+| P3 | **Declarative before imperative** | Prefer pack manifests, schemas, mappings, and registries over custom patch code. |
+| P4 | **Stable abstraction over unstable internals** | Low-level engine glue must be isolated from mod authoring surfaces. |
+| P5 | **Agent-first repository design** | The codebase and docs must optimize for autonomous agent development. |
+| P6 | **Observability is first-class** | Runtime must explain itself through logs, overlays, reports, validators. |
+| P7 | **Domain extensibility** | Warfare is the first domain plugin, not the only one. |
+| P8 | **Compatibility-aware packaging** | Mods must be packs with explicit dependencies, conflicts, versions. |
+| P9 | **Graceful degradation** | Missing assets/broken mappings fail loudly with fallbacks where safe. |
+
+### 2.3 Development Methodologies
+
+| Methodology | Description |
+|-------------|-------------|
+| **SDD** (Spec-Driven Development) | Specifications drive the pipeline |
+| **BDD** (Behavior-Driven Development) | Acceptance criteria before implementation |
+| **TDD** (Test-Driven Development) | Unit tests for all public APIs |
+| **DDD** (Domain-Driven Design) | Bounded contexts (Warfare, Economy, Scenario) |
+| **ADD** (Agent-Driven Development) | Fully agent-authored codebase |
+| **CDD** (Contract-Driven Development) | Schemas as contracts between packs and engine |
+
+---
+
+## 3. User Personas
+
+### 3.1 Primary: Product Owner / Mod Director
+
+**Needs:**
+- Request features in natural language
+- Avoid reading source code
+- Receive clear diagnostics when things fail
+- Iterate on gameplay, balance, and theming quickly
+- Add new mod concepts without fresh reverse engineering each time
+
+**Pain Points:**
+- Traditional modding requires deep engine knowledge
+- Debugging mod issues is time-consuming
+- Coordinating multiple mod components is complex
+
+### 3.2 Secondary: Autonomous Coding Agents
+
+**Needs:**
+- Clear public APIs with XML doc comments
+- Typed schemas for all data shapes
+- Examples and templates for common patterns
+- Deterministic build/test flows
+- Bounded ownership areas (agent roster)
+- Machine-readable contracts
+- Debugging tools and reports
+
+**Pain Points:**
+- Ambiguous API contracts
+- Missing test fixtures
+- Unclear file ownership boundaries
+
+### 3.3 Tertiary: End Users / Players
+
+**Needs:**
+- Install packs safely
+- Understand compatibility and conflicts
+- Get stable gameplay behavior
+- Receive understandable errors when packs fail
+
+**Pain Points:**
+- Manual mod installation is error-prone
+- Conflicting mods cause crashes
+- No clear indication of which packs are active
+
+---
+
+## 4. Architecture
+
+### 4.1 Three-Product Architecture
+
+DINOForge is structured as three distinct products with clear layering boundaries:
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                     DINOForge Architecture Stack                     │
+│                                                                      │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │  Product C: Content Packs                                    │   │
+│  │  ┌──────────────────────────────────────────────────────┐   │   │
+│  │  │  warfare-starwars/  # 28 units, 10 buildings         │   │   │
+│  │  │  warfare-modern/    # Modern military units           │   │   │
+│  │  │  warfare-guerrilla/ # Asymmetric warfare              │   │   │
+│  │  │  example-balance/   # Simple balance tweaks           │   │   │
+│  │  │                                                         │   │   │
+│  │  │  Each pack:                                             │   │   │
+│  │  │  ├── pack.yaml (manifest)                              │   │   │
+│  │  │  ├── units/ (unit definitions)                         │   │   │
+│  │  │  ├── buildings/ (building definitions)                 │   │   │
+│  │  │  └── assets/ (textures, models, audio)                 │   │   │
+│  │  └──────────────────────────────────────────────────────┘   │   │
+│  └──────────────────────────────────────────────────────────────┘   │
+│                                  │                                   │
+│                                  ▼                                   │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │  Domain Plugins (Extensible)                                 │   │
+│  │  ┌──────────────────────────────────────────────────────┐   │   │
+│  │  │  Warfare/                                              │   │   │
+│  │  │  ├── Archetypes/ (infantry, ranged, cavalry, artillery) │   │   │
+│  │  │  ├── Doctrines/ (combat bonuses, tech trees)           │   │   │
+│  │  │  ├── Roles/ (tank, dps, support, scout)                │   │   │
+│  │  │  ├── Waves/ (spawn patterns, difficulty scaling)       │   │   │
+│  │  │  └── Balance/ (formulas, resource costs)               │   │   │
+│  │  │                                                         │   │   │
+│  │  │  Economy/ (planned)                                     │   │   │
+│  │  │  Scenario/ (planned)                                    │   │   │
+│  │  │  UI/ (planned)                                          │   │   │
+│  │  └──────────────────────────────────────────────────────┘   │   │
+│  └──────────────────────────────────────────────────────────────┘   │
+│                                  │                                   │
+│                                  ▼                                   │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │  Product B: SDK Layer (Public API)                           │   │
+│  │  ┌──────────────────────────────────────────────────────┐   │   │
+│  │  │  Registry/ (TypedRegistry<T>, UnitRegistry, etc.)     │   │   │
+│  │  │  Models/ (Unit, Building, Faction, StatBlock, etc.)   │   │   │
+│  │  │  Validation/ (SchemaValidator, PackValidator)         │   │   │
+│  │  │  Assets/ (AddressablesCatalog, AssetSwapService)      │   │   │
+│  │  │  Dependencies/ (DependencyResolver)                   │   │   │
+│  │  │  Universe/ (UniverseBible, UniverseLoader)            │   │   │
+│  │  │  ContentLoader.cs (pack loading orchestration)        │   │   │
+│  │  └──────────────────────────────────────────────────────┘   │   │
+│  └──────────────────────────────────────────────────────────────┘   │
+│                                  │                                   │
+│                                  ▼                                   │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │  Product A: Runtime Layer (BepInEx Plugin)                   │   │
+│  │  ┌──────────────────────────────────────────────────────┐   │   │
+│  │  │  Plugin.cs (BepInEx entry point)                      │   │   │
+│  │  │  ModPlatform.cs (game lifecycle hooks)                │   │   │
+│  │  │                                                         │   │   │
+│  │  │  Bridge/                                                │   │   │
+│  │  │  ├── ComponentMap.cs (vanilla ↔ mod mapping)           │   │   │
+│  │  │  ├── EntityQueries.cs (ECS query helpers)              │   │   │
+│  │  │  ├── StatModifierSystem.cs (runtime stat overrides)    │   │   │
+│  │  │  └── VanillaCatalog.cs (vanilla data mirror)           │   │   │
+│  │  │                                                         │   │   │
+│  │  │  HotReload/                                             │   │   │
+│  │  │  ├── HotReloadBridge.cs (file watcher, reload trigger)  │   │   │
+│  │  │  └── ModuleState.cs (per-pack reload state)            │   │   │
+│  │  │                                                         │   │   │
+│  │  │  UI/                                                    │   │   │
+│  │  │  └── DebugOverlay.cs (F10 debug menu)                  │   │   │
+│  │  └──────────────────────────────────────────────────────┘   │   │
+│  └──────────────────────────────────────────────────────────────┘   │
+│                                  │                                   │
+│                                  ▼                                   │
+│  ┌──────────────────────────────────────────────────────────────┐   │
+│  │  Game: Diplomacy is Not an Option                            │   │
+│  │  └── Unity ECS (Entities 1.0.16)                             │   │
+│  │      ├── Unit entities (Health, Position, UnitId)            │   │
+│  │      ├── Building entities (Health, Position, BuildingId)    │   │
+│  │      └── Game systems (combat, economy, AI)                  │   │
+│  └──────────────────────────────────────────────────────────────┘   │
+│                                                                      │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### 4.2 Layer Communication
+
+```
+Content Packs ──YAML──► ContentLoader ──Registry──► ECS Bridge ──Components──► Game
+     │                      │                       │
+     │                      ▼                       ▼
+     │               SchemaValidator          StatModifierSystem
+     │                      │                       │
+     │                      ▼                       ▼
+     │               ValidationResult        Component Updates
+     │                                              │
+     ▼                                              ▼
+  PackCompiler                              DebugOverlay (F10)
+  (validate/build)                          (observability)
+```
+
+### 4.3 Content Layering Model
+
+DINOForge applies a 5-layer content model:
+
+| Layer | Description | Frequency | Target User |
+|-------|-------------|-----------|-------------|
+| **Content Packs** | YAML/JSON data — factions, units, stats, waves, localization | Most mods | Pack authors |
+| **Asset Packs** | Bundled art/audio/prefab with manifests | Visual/audio mods | Asset creators |
+| **Code Plugins** | C# plugin API through SDK interfaces | Advanced mods | Developers |
+| **Patch Layer** | Controlled Harmony patches (marked unsafe) | Rare | Runtime specialists |
+| **Tooling** | CLI tools, validators, inspectors | Development | All users |
+
+### 4.4 Registry Priority Layers
+
+```
+Priority 4000+
+┌─────────────────────────────────────────────────────────────┐
+│  User Override (runtime edits, debug tweaks)                 │
+└─────────────────────────────────────────────────────────────┘
+
+Priority 3000+
+┌─────────────────────────────────────────────────────────────┐
+│  Content Packs (mod content overrides)                       │
+│  ├── warfare-starwars: priority 3000                         │
+│  ├── warfare-modern: priority 3001                           │
+│  └── example-balance: priority 3500 (explicit)               │
+└─────────────────────────────────────────────────────────────┘
+
+Priority 2000+
+┌─────────────────────────────────────────────────────────────┐
+│  Domain Plugins (Warfare/Economy defaults)                   │
+│  ├── Archetype defaults (infantry: 100 HP base)              │
+│  └── Doctrine modifiers (+20% damage vs specific types)      │
+└─────────────────────────────────────────────────────────────┘
+
+Priority 1000+
+┌─────────────────────────────────────────────────────────────┐
+│  Framework Defaults (DINOForge baseline)                     │
+│  └── Default stat blocks, fallback values                    │
+└─────────────────────────────────────────────────────────────┘
+
+Priority 0+
+┌─────────────────────────────────────────────────────────────┐
+│  Base Game (vanilla DINO values)                             │
+│  └── Original unit/building stats from game files            │
+└─────────────────────────────────────────────────────────────┘
+
+Resolution Rule: Higher priority wins. Same priority = conflict error.
+```
+
+### 4.5 The Two-Boot Cycle
+
+DINO's game flow causes the Doorstop pre-loader to initialize **twice** per playthrough:
+
+1. **Boot 1**: Game launcher → load BepInEx → load Runtime plugin
+2. **Intermediate**: Scene loads, ECS world initializes
+3. **Boot 2**: Scene transition (or new game → continue) → Doorstop re-runs → must NOT double-initialize
+
+**Mechanism: HideAndDontSave + DontDestroyOnLoad**
+
+1. **HideAndDontSave flag** — Mark runtime root as not player-saveable
+2. **DontDestroyOnLoad marker** — Persist from Boot 1 → Boot 2
+3. **RuntimeDriver.OnDestroy resurrection** — If root destroyed by accident, create new one from marker
+4. **ModPlatform singleton pattern** — Only one instance ever exists; subsequent boots detect via static reference
+
+---
+
+## 5. Runtime Layer Specification
+
+### 5.1 Plugin Bootstrap
+
+**Entry Point:** `src/Runtime/Plugin.cs`
+
+```csharp
+[BepInPlugin(PluginGuid, PluginName, PluginVersion)]
+[BepInProcess("DINO.exe")]
+public class Plugin : BaseUnityPlugin
+{
+    public const string PluginGuid = "com.dinoforge.runtime";
+    public const string PluginName = "DINOForge Runtime";
+    public const string PluginVersion = "0.5.0";
+
+    private void Awake()
+    {
+        // Forward Unity callbacks to RuntimeDriver
+        RuntimeDriver.Initialize(this);
+    }
+}
+```
+
+**Responsibilities:**
+- BepInEx plugin registration
+- Unity callback forwarding to RuntimeDriver
+- Version detection and logging
+- Plugin lifecycle management
+
+### 5.2 ModPlatform Orchestrator
+
+**Location:** `src/Runtime/ModPlatform.cs`
+
+**Responsibilities:**
+- Game lifecycle hooks (world ready, scene changes)
+- Pack loading orchestration
+- Hot reload enablement
+- UI initialization (F9/F10 overlays)
+- ECS bridge synchronization
+
+**Lifecycle Flow:**
+
+```
+BepInEx Initializes (Plugin.OnEnable)
+  │
+  ▼
+Plugin.cs forwards Unity callbacks to RuntimeDriver
+  │
+  ▼
+RuntimeDriver.Update — Frame 0: Detect ECS World
+  │
+  ▼
+RuntimeDriver.OnDestroy — called at frame ~1
+  │
+  ▼
+ModPlatform.Initialize — Create root + load SDK
+  │
+  ▼
+Root marked: HideAndDontSave + DontDestroyOnLoad
+  │
+  ▼
+RuntimeDriver resurrected in OnDestroy via DontDestroyOnLoad marker
+  │
+  ▼
+ModPlatform.OnWorldReady — Load packs, enable HMR, start UI
+  │
+  ▼
+F9/F10 overlays active across scene reloads
+```
+
+### 5.3 ECS Bridge
+
+**Location:** `src/Runtime/Bridge/`
+
+#### ComponentMap
+
+Maps vanilla ECS components to mod-aware equivalents:
+
+| Vanilla Component | DINOForge Bridge Component | Sync Direction | Frequency |
+|-------------------|---------------------------|----------------|-----------|
+| Health | StatOverrideComponent | Mod → Game | Per-frame |
+| UnitId | ModUnitDefinitionComponent | Game → Mod | On-spawn |
+| Position | (read-only query) | Game → Mod | On-demand |
+| MeshRenderer | AssetSwapComponent | Mod → Game | On-load |
+| Material | AssetSwapComponent | Mod → Game | On-load |
+
+#### EntityQueries
+
+ECS query helpers for mod content:
+
+```csharp
+public static class EntityQueries
+{
+    public static IEnumerable<Entity> GetUnitsByFaction(
+        EntityManager em, string factionId)
+    {
+        var query = em.CreateEntityQuery(
+            typeof(UnitIdComponent),
+            typeof(HealthComponent),
+            typeof(PositionComponent));
+
+        var entities = query.ToEntityArray(Allocator.Temp);
+
+        foreach (var entity in entities)
+        {
+            var unitId = em.GetComponentData<UnitIdComponent>(entity);
+            if (unitId.FactionId == factionId)
+            {
+                yield return entity;
+            }
+        }
+
+        entities.Dispose();
+    }
+}
+```
+
+#### StatModifierSystem
+
+Runtime stat override system:
+
+```csharp
+[BurstCompile]
+public partial struct StatModifierSystem : ISystem
+{
+    public void OnUpdate(ref SystemState state)
+    {
+        foreach (var (health, modDef, overrides) in SystemAPI
+            .Query<RefRW<HealthComponent>,
+                   RefRO<ModUnitDefinitionComponent>,
+                   RefRO<StatOverrideComponent>>())
+        {
+            var baseHealth = modDef.ValueRO.Definition.Stats.Health;
+            var overrideValue = overrides.ValueRO.GetOverride("health");
+
+            health.ValueRW.Max = overrideValue ?? baseHealth;
+        }
+    }
+}
+```
+
+#### VanillaCatalog
+
+Mirror of vanilla game data for reference and fallback:
+
+```csharp
+public static class VanillaCatalog
+{
+    public static IReadOnlyDictionary<string, UnitDefinition> Units { get; private set; }
+    public static IReadOnlyDictionary<string, BuildingDefinition> Buildings { get; private set; }
+
+    public static void Initialize(EntityManager entityManager)
+    {
+        // Dump all vanilla entities and cache their definitions
+        Units = DumpVanillaUnits(entityManager);
+        Buildings = DumpVanillaBuildings(entityManager);
+    }
+}
+```
+
+### 5.4 Hot Reload Bridge
+
+**Location:** `src/Runtime/HotReload/`
+
+**Mechanisms:**
+- **FileSystemWatcher**: Detects YAML changes in packs directory
+- **Debouncer**: 500ms debounce to batch rapid changes
+- **Manual Trigger**: F10 key for explicit reload
+- **ModuleState**: Per-pack reload state tracking
+
+**Reload Flow:**
+
+```
+File Change Detected
+  │
+  ▼
+Debouncer (500ms)
+  │
+  ▼
+ContentLoader.ReloadPack(packPath)
+  │
+  ├── Schema Validation
+  ├── Dependency Check
+  ├── Registry Update
+  └── ECS Sync
+  │
+  ▼
+Result: Success / Failure (with error details)
+```
+
+### 5.5 Debug Overlay
+
+**Location:** `src/Runtime/UI/DebugOverlay.cs`
+
+**Activation:** F10 key in-game
+
+**Features:**
+- Entity counts by type
+- System state information
+- Loaded pack list
+- Error/warning log
+- Performance metrics
+
+---
+
+## 6. SDK Layer Specification
+
+### 6.1 Public API Surface
+
+The SDK (`DINOForge.SDK`, target: `netstandard2.0`) provides the public mod API:
+
+| Namespace | Purpose |
+|-----------|---------|
+| `DINOForge.SDK.Registry` | Typed registries for all content types |
+| `DINOForge.SDK.Models` | Data models (Unit, Building, Faction, etc.) |
+| `DINOForge.SDK.Validation` | Schema validation utilities |
+| `DINOForge.SDK.Assets` | Asset management services |
+| `DINOForge.SDK.Dependencies` | Dependency resolution |
+| `DINOForge.SDK.Universe` | Universe Bible system |
+| `DINOForge.SDK.HotReload` | Pack file watcher |
+
+### 6.2 ContentLoader
+
+**Location:** `src/SDK/ContentLoader.cs`
+
+**Responsibilities:**
+- Discover pack.yaml files in packs directory
+- Parse YAML manifests
+- Resolve dependencies (topological sort)
+- Validate content against schemas
+- Register content to typed registries
+- Return load results with errors/warnings
+
+**Load Pipeline:**
+
+```
+1. DISCOVERY
+   └── Scan packs/ directory for pack.yaml files
+
+2. PARSING
+   └── Parse YAML manifests (id, version, dependencies, loads)
+
+3. DEPENDENCY RESOLUTION
+   └── Topological sort based on dependency graph
+   └── Detect circular dependencies (error)
+   └── Detect version conflicts (error)
+
+4. VALIDATION
+   └── Schema validation per content type
+   └── Cross-reference validation (IDs exist)
+   └── Asset existence check
+
+5. REGISTRATION
+   └── Register to TypedRegistry<T> with priority
+   └── Apply overrides to existing entries
+   └── Store source pack ID for conflict detection
+
+6. BRIDGE SYNC
+   └── Sync registered content to ECS components
+   └── Spawn/refresh entity components
+```
+
+**Error Handling:**
+- Validation failure → Skip pack, log error, continue
+- Dependency missing → Error, halt load
+- Conflict detected → Error, show in debug overlay
+
+### 6.3 Data Models
+
+#### UnitDefinition
+
+```csharp
+public record UnitDefinition
+{
+    public string Id { get; init; } = "";
+    public string Name { get; init; } = "";
+    public string Description { get; init; } = "";
+    public string Archetype { get; init; } = "";
+    public string Role { get; init; } = "";
+    public string Faction { get; init; } = "";
+    public VisualDefinition Visual { get; init; } = new();
+    public StatBlock Stats { get; init; } = new();
+    public CombatBlock Combat { get; init; } = new();
+    public CostBlock Cost { get; init; } = new();
+    public List<AbilityDefinition> Abilities { get; init; } = new();
+    public List<UnitVariantDefinition> Variants { get; init; } = new();
+}
+```
+
+#### BuildingDefinition
+
+```csharp
+public record BuildingDefinition
+{
+    public string Id { get; init; } = "";
+    public string Name { get; init; } = "";
+    public string Description { get; init; } = "";
+    public string Faction { get; init; } = "";
+    public VisualDefinition Visual { get; init; } = new();
+    public StatBlock Stats { get; init; } = new();
+    public CostBlock Cost { get; init; } = new();
+    public ProductionBlock Production { get; init; } = new();
+}
+```
+
+#### FactionDefinition
+
+```csharp
+public record FactionDefinition
+{
+    public string Id { get; init; } = "";
+    public string Name { get; init; } = "";
+    public string Description { get; init; } = "";
+    public string Archetype { get; init; } = "";
+    public List<string> Units { get; init; } = new();
+    public List<string> Buildings { get; init; } = new();
+    public List<string> Doctrines { get; init; } = new();
+    public FactionColors Colors { get; init; } = new();
+}
+```
+
+#### PackManifest
+
+```csharp
+public record PackManifest
+{
+    public string Id { get; init; } = "";
+    public string Name { get; init; } = "";
+    public string Version { get; init; } = "";
+    public string Author { get; init; } = "";
+    public string Type { get; init; } = "";
+    public string FrameworkVersion { get; init; } = "";
+    public string Description { get; init; } = "";
+    public string Homepage { get; init; } = "";
+    public string License { get; init; } = "";
+    public int Priority { get; init; } = 3000;
+    public PackLoadConfig Loads { get; init; } = new();
+    public List<DependencyDefinition> Depends { get; init; } = new();
+    public List<ConflictDefinition> Conflicts { get; init; } = new();
+    public AssetConfig Assets { get; init; } = new();
+}
+```
+
+---
+
+## 7. Domain Plugin Specification
+
+### 7.1 Domain Plugin Architecture
+
+Domain plugins extend DINOForge with game-specific logic. Each domain plugin:
+
+- References the SDK (`DINOForge.SDK`)
+- Registers domain-specific content to registries
+- Provides domain-specific schemas
+- Implements domain-specific validation rules
+
+**Current Domains:**
+
+| Domain | Status | Content Types |
+|--------|--------|---------------|
+| **Warfare** | ✅ Production | Archetypes, Doctrines, Roles, Waves, Balance |
+| **Economy** | 🔄 In Progress | Resources, Trade, Production |
+| **Scenario** | 🔄 In Progress | Events, Conditions, Win/Loss |
+| **UI** | 🔄 In Progress | Themes, HUD elements, Menus |
+
+### 7.2 Warfare Domain
+
+**Location:** `src/Domains/Warfare/`
+
+#### Faction Archetypes
+
+| Archetype | Traits | Used By |
+|-----------|--------|---------|
+| **Order** | Strong line infantry, reliable DPS, better defenses, higher unit cost | Republic, West |
+| **Industrial Swarm** | Larger numbers, cheaper core, expendable, strong siege | CIS, Classic West Enemy |
+| **Asymmetric** | Light units, mobility, ambush, raid pressure, structure harassment | Guerrilla West Enemy |
+
+#### Doctrines
+
+Doctrines provide combat bonuses and strategic modifiers:
+
+```yaml
+# doctrines/elite_discipline.doctrine.yaml
+id: warfare:elite_discipline
+name: "Elite Discipline"
+description: "Units fight with superior coordination"
+
+effects:
+  - type: stat_modifier
+    target: archetype:infantry
+    stat: accuracy
+    value: +15
+    condition: formation == line
+
+  - type: stat_modifier
+    target: archetype:ranged
+    stat: fire_rate
+    value: +10
+    condition: has_support_unit
+```
+
+#### Unit Roles
+
+| Role | Description | Typical Stats |
+|------|-------------|---------------|
+| **Frontline** | Absorbs damage, holds the line | High HP, high armor, moderate DPS |
+| **DPS** | Primary damage dealer | Low HP, high damage, moderate range |
+| **Support** | Buffs allies, debuffs enemies | Low HP, aura effects, utility |
+| **Scout** | Fast, low-cost reconnaissance | High speed, low HP, low cost |
+| **Siege** | Structure destruction specialist | Very high damage vs buildings, slow |
+
+#### Wave System
+
+Waves define enemy composition and spawn patterns:
+
+```yaml
+# waves/wave_01.wave.yaml
+id: starwars:wave_01
+name: "CIS First Assault"
+difficulty: easy
+
+composition:
+  - unit: cis:battle_droid
+    count: 20
+    spawn_delay: 0.5
+  - unit: cis:droid_tank
+    count: 3
+    spawn_delay: 2.0
+  - unit: cis:droideka
+    count: 5
+    spawn_delay: 1.0
+
+spawn_pattern:
+  type: staggered
+  interval: 3.0
+  location: enemy_base
+
+objectives:
+  - type: destroy_all
+    timeout: 300
+```
+
+### 7.3 Domain Plugin Contract
+
+```csharp
+public interface IDomainPlugin
+{
+    string DomainId { get; }
+    string DomainName { get; }
+    string Version { get; }
+
+    void RegisterRegistries(IRegistryCollection registries);
+    void RegisterSchemas(ISchemaRegistry schemas);
+    void RegisterValidators(IValidatorCollection validators);
+    void Initialize(IContentLoadResult content);
+}
+```
+
+---
+
+## 8. Pack System Specification
+
+### 8.1 Pack Manifest Schema
+
+```yaml
+# Required fields
+id: warfare-starwars                    # Unique pack identifier
+name: "Star Wars: Clone Wars"           # Display name
+version: 1.0.0                          # Semantic version
+author: DINOForge Team                  # Author name
+type: total-conversion                  # Pack type
+framework_version: ">=0.1.0"            # DINOForge compatibility
+
+# Optional fields
+description: "Republic vs CIS faction warfare"
+homepage: https://github.com/KooshaPari/Dino
+license: MIT
+
+# Load configuration
+loads:
+  units:
+    - units/           # Relative to pack root
+  buildings:
+    - buildings/
+  factions:
+    - factions/
+  waves:
+    - waves/
+
+# Dependencies
+depends:
+  - id: dinoforge-core
+    version: ">=0.1.0"
+    optional: false
+  - id: warfare-assets-base
+    version: "~1.0.0"
+    optional: true
+
+# Conflicts (mutually exclusive packs)
+conflicts:
+  - id: warfare-fantasy
+    reason: "Different theme setting"
+
+# Priority for registry resolution (higher = wins)
+priority: 3000
+
+# Asset bundle configuration
+assets:
+  bundle_name: "warfare_starwars_bundle"
+  addressables_group: "warfare-starwars"
+```
+
+### 8.2 Pack Types
+
+| Type | Description | Example |
+|------|-------------|---------|
+| **content** | New units, buildings, factions | warfare-modern |
+| **balance** | Stat adjustments, cost changes | example-balance |
+| **ruleset** | Research, wave, victory condition changes | (planned) |
+| **total-conversion** | Complete faction/theme replacement | warfare-starwars |
+| **utility** | Debug tools, QoL improvements | (planned) |
+
+### 8.3 Pack Loading Order
+
+```
+1. Discover all pack.yaml files
+2. Parse manifests into PackManifest objects
+3. Build dependency graph
+4. Topological sort → load order
+5. For each pack in order:
+   a. Validate content against schemas
+   b. Check dependencies are satisfied
+   c. Check no conflicts with already-loaded packs
+   d. Load content files (units/, buildings/, etc.)
+   e. Register to TypedRegistry<T> with pack priority
+   f. Track source pack for conflict detection
+6. Sync registries to ECS bridge
+7. Enable hot reload watcher
+```
+
+### 8.4 Pack Submodule Management
+
+**CLI Commands:**
+- `dinoforge pack add <url>` — Add git submodule pack
+- `dinoforge pack list` — List all packs with status
+- `dinoforge pack update <id>` — Update pack to latest
+- `dinoforge pack lock <id> <commit>` — Lock pack to specific commit
+
+**Lock File:** `packs.lock`
+
+```yaml
+# packs.lock
+lockfile_version: 1
+packs:
+  - id: warfare-starwars
+    path: packs/warfare-starwars
+    url: https://github.com/KooshaPari/dinoforge-packs
+    commit: abc123def456
+    branch: main
+    locked_at: 2026-04-04T12:00:00Z
+```
+
+---
+
+## 9. Registry System Specification
+
+### 9.1 Registry Architecture
+
+```
+TypedRegistry<T> (generic base)
+├── UnitRegistry (IRegistry<UnitDefinition>)
+├── BuildingRegistry (IRegistry<BuildingDefinition>)
+├── FactionRegistry (IRegistry<FactionDefinition>)
+├── WeaponRegistry (IRegistry<WeaponDefinition>)
+├── ProjectileRegistry (IRegistry<ProjectileDefinition>)
+├── DoctrineRegistry (IRegistry<DoctrineDefinition>)
+├── SkillRegistry (IRegistry<SkillDefinition>)
+├── WaveRegistry (IRegistry<WaveDefinition>)
+└── SquadRegistry (IRegistry<SquadDefinition>)
+```
+
+### 9.2 Registry Interface
+
+```csharp
+public interface IRegistry<T> where T : class, IRegisteredContent
+{
+    void Register(string id, T content, int priority, string sourcePack);
+    T? Get(string id);
+    IReadOnlyDictionary<string, T> GetAll();
+    IReadOnlyList<string> GetConflicts();
+    bool Contains(string id);
+    int Count { get; }
+}
+```
+
+### 9.3 Priority Resolution
+
+| Priority Range | Source | Example |
+|---------------|--------|---------|
+| 0-999 | Base game (vanilla DINO) | Original unit stats |
+| 1000-1999 | Framework defaults | DINOForge baseline values |
+| 2000-2999 | Domain plugins | Warfare archetype defaults |
+| 3000-3999 | Content packs | Mod content overrides |
+| 4000+ | User overrides | Runtime debug tweaks |
+
+**Resolution Rule:** Higher priority wins. Same priority = conflict detected and reported.
+
+### 9.4 Conflict Detection
+
+```csharp
+public IReadOnlyList<string> GetConflicts()
+{
+    return _entries
+        .Where(kvp => kvp.Value.Count > 1
+            && kvp.Value[0].Priority == kvp.Value[1].Priority)
+        .Select(kvp => kvp.Key)
+        .ToList();
+}
+```
+
+Conflicts are reported in:
+- Debug overlay (F10)
+- PackCompiler validation output
+- Desktop Companion conflict view
+- CI/CD pipeline (blocking)
+
+---
+
+## 10. Schema Validation Specification
+
+### 10.1 Schema Inventory
+
+| Schema File | Content Type | Draft | Required Fields |
+|-------------|-------------|-------|-----------------|
+| `pack.schema.json` | Pack manifest | Draft 7 | id, name, version, author, type |
+| `unit.schema.json` | Unit definition | Draft 7 | id, name, stats |
+| `building.schema.json` | Building definition | Draft 7 | id, name, stats |
+| `faction.schema.json` | Faction definition | Draft 7 | id, name, archetype |
+| `weapon.schema.json` | Weapon definition | Draft 7 | id, name, damage |
+| `projectile.schema.json` | Projectile definition | Draft 7 | id, name, speed |
+| `doctrine.schema.json` | Doctrine definition | Draft 7 | id, name, effects |
+| `skill.schema.json` | Skill definition | Draft 7 | id, name, effect |
+| `wave.schema.json` | Wave definition | Draft 7 | id, name, composition |
+| `squad.schema.json` | Squad definition | Draft 7 | id, name, units |
+| `archetype.schema.json` | Unit archetype | Draft 7 | id, name, traits |
+| `role.schema.json` | Unit role | Draft 7 | id, name, description |
+| `ability.schema.json` | Ability definition | Draft 7 | id, name, effect |
+| `variant.schema.json` | Unit variant | Draft 7 | id, name, stat_modifiers |
+| `economy.schema.json` | Economy profile | Draft 7 | id, name, resources |
+| `scenario.schema.json` | Scenario definition | Draft 7 | id, name, conditions |
+| `universe.schema.json` | Universe Bible | Draft 7 | id, name, factions |
+
+### 10.2 Validation Rules
+
+| Rule | Severity | Description |
+|------|----------|-------------|
+| **id_format** | Error | Must match `^[a-z0-9_]+:[a-z0-9_]+$` |
+| **required_fields** | Error | Required fields must be present |
+| **reference_exists** | Error | Referenced IDs must exist in registry |
+| **asset_exists** | Warning | Referenced asset files must exist |
+| **stat_range** | Warning | Stats must be within reasonable bounds |
+| **cost_balance** | Warning | Costs should follow archetype guidelines |
+| **unique_ids** | Error | No duplicate IDs within a pack |
+| **circular_deps** | Error | No circular dependencies between packs |
+| **version_compat** | Error | framework_version must match current DINOForge |
+| **conflict_check** | Error | No conflicts with loaded packs at same priority |
+
+### 10.3 Validation Pipeline
+
+```
+Input: pack.yaml + content files
+  │
+  ▼
+┌─────────────────────┐
+│  YAML Parsing       │  YamlDotNet
+│  → C# Objects       │
+└────────┬────────────┘
+         │
+         ▼
+┌─────────────────────┐
+│  Schema Validation  │  NJsonSchema
+│  (per content type) │  pack.schema.json, unit.schema.json, etc.
+└────────┬────────────┘
+         │
+         ▼
+┌─────────────────────┐
+│  Cross-Reference    │  Check referenced IDs exist
+│  Validation         │  Check asset files exist
+└────────┬────────────┘
+         │
+         ▼
+┌─────────────────────┐
+│  Dependency         │  Resolve dependency graph
+│  Validation         │  Detect circular deps
+└────────┬────────────┘
+         │
+         ▼
+┌─────────────────────┐
+│  Conflict           │  Check priority conflicts
+│  Detection          │  Check version compatibility
+└────────┬────────────┘
+         │
+         ▼
+  ValidationResult: Pass / Fail (with errors)
+```
+
+---
+
+## 11. ECS Bridge Specification
+
+### 11.1 Component Mapping
+
+The ECS bridge maps DINOForge's mod content definitions to DINO's actual Unity ECS components:
+
+| Mod Concept | Vanilla ECS Component | Bridge Component | Notes |
+|-------------|----------------------|------------------|-------|
+| Unit health | HealthComponent | StatOverrideComponent | Override at runtime |
+| Unit identity | UnitIdComponent | ModUnitDefinitionComponent | Link to mod definition |
+| Unit visuals | MeshRenderer | AssetSwapComponent | Replace prefab |
+| Unit materials | MaterialProperty | AssetSwapComponent | Replace materials |
+| Building health | HealthComponent | StatOverrideComponent | Same as units |
+| Building identity | BuildingIdComponent | ModBuildingDefinitionComponent | Link to mod definition |
+| Faction affiliation | FactionComponent | (read-only) | Query only |
+| Position | LocalTransform | (read-only) | Query only |
+
+### 11.2 Bridge Systems
+
+| System | Purpose | Execution |
+|--------|---------|-----------|
+| **ModComponentInjectionSystem** | Adds mod components to entities | On entity creation |
+| **StatOverrideSystem** | Applies stat overrides per frame | Every frame (Burst) |
+| **AssetSwapSystem** | Replaces visuals on load | On pack load |
+| **FactionSystem** | Manages faction-specific behavior | On faction change |
+| **WaveInjectorSystem** | Injects mod waves into game | On wave trigger |
+| **VanillaArchetypeMapper** | Maps vanilla units to mod archetypes | On pack load |
+
+### 11.3 Performance Guarantees
+
+| Metric | Target | Current | Measurement |
+|--------|--------|---------|-------------|
+| **ECS sync overhead** | <1ms/frame | ~0.3ms | 1000 entities |
+| **Component query** | <1μs | ~0.5μs | Single lookup |
+| **Stat application** | <0.5ms/1000 units | ~0.2ms | Per-frame batch |
+| **Asset swap** | <100ms | ~50ms | Per prefab |
+
+---
+
+## 12. Asset Pipeline Specification
+
+### 12.1 Pipeline Stages
+
+```
+Stage 1: Import
+  Input: Source assets (FBX, PNG, WAV)
+  Process: Format validation, metadata extraction
+  Output: Validated source files
+  Tool: assetctl import
+
+Stage 2: Validate
+  Input: Validated source files
+  Process: Technical checks (poly count, UVs, texture size)
+  Output: Validation report
+  Tool: assetctl validate
+
+Stage 3: Optimize
+  Input: Validated source files
+  Process: Compression, LOD generation, texture atlasing
+  Output: Optimized assets
+  Tool: assetctl optimize
+
+Stage 4: Build
+  Input: Optimized assets
+  Process: Prefab creation, Addressables catalog
+  Output: Addressables bundle
+  Tool: assetctl build
+
+Stage 5: Catalog
+  Input: Addressables bundle
+  Process: SQLite catalog entry, source adapter
+  Output: AssetCatalogStore entry
+  Tool: assetctl catalog
+```
+
+### 12.2 LOD Generation
+
+| Level | Quality | Distance | Use Case |
+|-------|---------|----------|----------|
+| **LOD 0** | 100% | 0-30 units | Close-up, hero units |
+| **LOD 1** | 60% | 30-60 units | Mid-range, standard view |
+| **LOD 2** | 30% | 60+ units | Far view, mass battles |
+
+### 12.3 Addressables Catalog
+
+```
+Content Packs
+├── warfare-starwars (Group)
+│   ├── Units/
+│   │   ├── clone_trooper.prefab → bundle_units_abc123
+│   │   ├── battle_droid.prefab → bundle_units_abc123
+│   │   └── ...
+│   ├── Buildings/
+│   │   ├── republic_barracks.prefab → bundle_buildings_def456
+│   │   └── ...
+│   └── Assets/
+│       ├── Materials/
+│       ├── Textures/
+│       ├── Models/
+│       └── Animations/
+│
+├── warfare-modern (Group)
+├── example-balance (Group - data only)
+└── ...
+
+Catalog.json (runtime asset lookup)
+└── Maps Addressables keys → bundle hashes → download URLs
+```
+
+### 12.4 SQLite Asset Catalog
+
+The `AssetCatalogStore` maintains a SQLite database of all assets:
+
+```sql
+CREATE TABLE assets (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL,  -- 'model', 'texture', 'audio', 'prefab'
+    pack_id TEXT NOT NULL,
+    source_path TEXT NOT NULL,
+    addressable_key TEXT,
+    bundle_hash TEXT,
+    lod_levels INTEGER DEFAULT 1,
+    file_size INTEGER,
+    created_at TEXT,
+    updated_at TEXT
+);
+
+CREATE TABLE sources (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    type TEXT NOT NULL,  -- 'local', 'sketchfab', 'url'
+    config TEXT  -- JSON configuration
+);
+```
+
+---
+
+## 13. Hot Reload Specification
+
+### 13.1 Reload Triggers
+
+| Trigger | Latency | Use Case |
+|---------|---------|----------|
+| **FileSystemWatcher** | ~300ms | Automatic on YAML save |
+| **Manual F10** | ~100ms | Explicit reload request |
+| **MCP reload_packs** | ~200ms | AI agent-triggered |
+| **WebSocket** | ~50ms | External tool trigger (planned) |
+
+### 13.2 Reload Process
+
+```
+1. Detect file change (FileSystemWatcher or manual trigger)
+2. Debounce (500ms) to batch rapid changes
+3. Identify affected pack(s)
+4. Validate changed content against schemas
+5. Update registry entries (add/modify/remove)
+6. Sync changes to ECS bridge
+7. Update debug overlay
+8. Log result (success/failure with details)
+```
+
+### 13.3 State Preservation
+
+| State Type | Preserved? | Notes |
+|------------|-----------|-------|
+| **Registry entries** | ✅ Yes | Updated in-place |
+| **ECS components** | ✅ Yes | Updated on existing entities |
+| **Spawned entities** | ✅ Yes | Stats updated, visuals swapped |
+| **Game progress** | ✅ Yes | No game state lost |
+| **User settings** | ✅ Yes | Stored separately |
+
+---
+
+## 14. MCP Server Specification
+
+### 14.1 Server Architecture
+
+```
+Claude Code / AI Agent
+  │
+  ▼
+HTTP Transport (JSON-RPC 2.0) — Port 8765
+  │
+  ▼
+MCP Server (FastMCP C# / Python)
+  │
+  ├── Game Query Tools
+  ├── Game Control Tools
+  ├── Asset Pipeline Tools
+  ├── Pack Management Tools
+  ├── Log Analysis Tools
+  └── UI Automation Tools
+  │
+  ▼
+Game Process (via Named Pipes Bridge)
+  ├── ECS World (entities, components)
+  ├── BepInEx Plugin (DINOForge Runtime)
+  └── Named Pipes Bridge
+```
+
+### 14.2 Tool Inventory
+
+| Tool | Category | Purpose | Latency |
+|------|----------|---------|---------|
+| `game_status` | Query | Check if game is running and mods loaded | ~50ms |
+| `game_query_entities` | Query | Query ECS entities by component type | ~100ms |
+| `game_get_stat` | Query | Read a stat value on an entity | ~50ms |
+| `game_apply_override` | Control | Apply a stat override | ~100ms |
+| `game_reload_packs` | Control | Hot-reload packs without restarting | ~200ms |
+| `game_dump_state` | Control | Trigger entity dump to file | ~500ms |
+| `game_screenshot` | Automation | Capture game window screenshot | ~500ms |
+| `game_verify_mod` | Query | Verify mod is loaded and active | ~50ms |
+| `game_wait_for_world` | Query | Wait until ECS world is ready | ~100ms |
+| `game_ui_automation` | Automation | Automate game UI interactions | ~500ms |
+| `game_launch_test` | Control | Launch TEST instance (second concurrent DINO) | ~5s |
+| `game_analyze_screen` | Automation | Detect UI elements via OmniParser | ~1s |
+| `game_input` | Automation | Inject keyboard/mouse input (Win32 SendInput) | ~1ms |
+| `game_wait_and_screenshot` | Automation | Poll for visual change then capture | ~1s |
+| `game_navigate_to` | Automation | Navigate to game state via input sequences | ~2s |
+| `asset_validate` | Asset | Validate asset against technical requirements | ~200ms |
+| `asset_import` | Asset | Import asset into pipeline | ~500ms |
+| `asset_optimize` | Asset | Optimize asset (LOD, compression) | ~1s |
+| `asset_build` | Asset | Build Addressables bundle | ~2s |
+| `pack_validate` | Pack | Validate pack against schemas | ~200ms |
+| `pack_build` | Pack | Build pack artifact | ~1s |
+| `pack_list` | Pack | List all installed packs | ~50ms |
+| `log_tail` | Log | Read recent log entries | ~50ms |
+| `dump_state` | Log | Get current entity dump status | ~100ms |
+| `swap_status` | Log | Check asset swap operation status | ~50ms |
+
+### 14.3 Transport Configuration
+
+```json
+{
+  "mcpServers": {
+    "dinoforge": {
+      "url": "http://127.0.0.1:8765"
+    }
+  }
+}
+```
+
+### 14.4 Multi-Instance Orchestration (ADR-022)
+
+| Range | Purpose | Allocation |
+|-------|---------|------------|
+| 8765 | Primary instance | Fixed |
+| 8766-8799 | Test instances | Dynamic |
+| 8800-8899 | Scenario instances | Dynamic |
+| 8900+ | Reserved | Future |
+
+**Heartbeat Protocol:**
+- MCP Server sends heartbeat every 30s to registry
+- Missing 3 heartbeats → Mark unhealthy
+- Missing 5 heartbeats → Auto-deregister
+
+---
+
+## 15. Desktop Companion Specification
+
+### 15.1 Architecture
+
+```
+Desktop Companion (WinUI 3)
+├── NavigationView Shell
+│   ├── Pack Manager
+│   │   ├── Pack List (Virtualized GridView)
+│   │   ├── Pack Details Panel
+│   │   ├── Enable/Disable Toggle
+│   │   └── Conflict Indicators
+│   ├── Asset Browser
+│   │   ├── Asset Grid (SQLite-backed)
+│   │   ├── Asset Preview
+│   │   └── Search & Filter
+│   ├── Mod Manager
+│   │   ├── Installed Mods
+│   │   ├── Available Updates
+│   │   └── Conflict Detection
+│   └── Debug Panel
+│       ├── Entity Counts
+│       ├── System State
+│       └── Error Log
+│
+├── State Management
+│   ├── disabled_packs.json (shared with game)
+│   ├── PackFileWatcher (500ms debounce)
+│   └── SDK direct reference (netstandard2.0)
+│
+└── UI Framework
+    ├── WinUI 3 + Windows App SDK
+    ├── Mica material background
+    └── Dark color tokens matching DinoForgeStyle.cs
+```
+
+### 15.2 State Parity
+
+The Desktop Companion reads/writes `disabled_packs.json` which is shared with the game runtime:
+
+```json
+{
+  "disabled_packs": [
+    "warfare-guerrilla",
+    "example-balance"
+  ],
+  "last_updated": "2026-04-04T12:00:00Z"
+}
+```
+
+### 15.3 Pack File Watcher
+
+- Watches packs directory for YAML changes
+- 500ms debounce to batch rapid changes
+- Reloads companion state on change
+- Uses SDK `PackFileWatcher` directly
+
+---
+
+## 16. CLI Tool Specification
+
+### 16.1 PackCompiler CLI
+
+| Command | Purpose | Example |
+|---------|---------|---------|
+| `validate` | Validate pack against schemas | `packcompiler validate packs/warfare-starwars` |
+| `build` | Build pack with Addressables | `packcompiler build packs/warfare-starwars` |
+| `package` | Create distributable zip | `packcompiler package packs/warfare-starwars` |
+| `deps` | Analyze dependencies | `packcompiler deps packs/warfare-starwars` |
+| `conflicts` | Detect content conflicts | `packcompiler conflicts` |
+
+### 16.2 dinoforge CLI
+
+| Command | Purpose | Example |
+|---------|---------|---------|
+| `pack add` | Add git submodule pack | `dinoforge pack add <url>` |
+| `pack list` | List all packs with status | `dinoforge pack list` |
+| `pack update` | Update pack to latest | `dinoforge pack update warfare-starwars` |
+| `pack lock` | Lock pack to specific commit | `dinoforge pack lock warfare-starwars abc123` |
+| `asset import` | Import asset into pipeline | `dinoforge asset import model.fbx` |
+| `asset validate` | Validate asset | `dinoforge asset validate model.fbx` |
+| `asset optimize` | Optimize asset | `dinoforge asset optimize model.fbx` |
+| `asset build` | Build Addressables bundle | `dinoforge asset build warfare-starwars` |
+| `asset library` | Query asset catalog | `dinoforge asset library search clone` |
+| `install` | Install DINOForge | `dinoforge install` |
+| `status` | Project health summary | `dinoforge status` |
+
+---
+
+## 17. API Reference
+
+### 17.1 SDK Public API
+
+#### Registry API
+
+```csharp
+// Register content
+registry.Register("starwars:clone_trooper", unit, priority: 3000, sourcePack: "warfare-starwars");
+
+// Get content
+var unit = registry.Get<UnitDefinition>("starwars:clone_trooper");
+
+// Get all content
+var allUnits = registry.GetAll<UnitDefinition>();
+
+// Check conflicts
+var conflicts = registry.GetConflicts<UnitDefinition>();
+
+// Check existence
+bool exists = registry.Contains("starwars:clone_trooper");
+
+// Count
+int count = registry.Count<UnitDefinition>();
+```
+
+#### ContentLoader API
+
+```csharp
+// Load all packs
+var result = await ContentLoader.LoadPacksAsync(packsDir);
+
+// Reload single pack
+var reloadResult = await ContentLoader.ReloadPackAsync(packPath);
+
+// Get load errors
+var errors = result.Errors;
+
+// Get loaded packs
+var packs = result.LoadedPacks;
+```
+
+#### SchemaValidator API
+
+```csharp
+// Validate content
+var result = await validator.ValidateAsync(contentPath, "unit");
+
+// Check result
+if (result.IsValid)
+{
+    // Content is valid
+}
+else
+{
+    foreach (var error in result.Errors)
+    {
+        Console.WriteLine($"{error.Path}: {error.Message}");
+    }
+}
+```
+
+#### DependencyResolver API
+
+```csharp
+// Resolve dependencies
+var result = resolver.Resolve(manifests);
+
+if (result.IsSuccess)
+{
+    var loadOrder = result.LoadOrder; // Topologically sorted
+}
+else
+{
+    Console.WriteLine(result.Error); // Circular dependency, missing dep, etc.
+}
+```
+
+### 17.2 Runtime API
+
+#### ModPlatform API
+
+```csharp
+// Initialize (called by RuntimeDriver)
+ModPlatform.Initialize();
+
+// On world ready (called by ModPlatform)
+ModPlatform.OnWorldReady(entityManager);
+
+// Get loaded packs
+var packs = ModPlatform.LoadedPacks;
+
+// Get registry
+var registry = ModPlatform.Registry;
+```
+
+#### ECS Bridge API
+
+```csharp
+// Apply stat override
+StatModifierSystem.ApplyOverride(entityId, "health", 200f);
+
+// Swap asset
+AssetSwapService.SwapUnitPrefab("starwars:clone_trooper", "new_prefab_key");
+
+// Query entities
+var units = EntityQueries.GetUnitsByFaction(entityManager, "starwars:galactic_republic");
+```
+
+### 17.3 MCP API
+
+All MCP tools follow the JSON-RPC 2.0 protocol:
+
+```json
+// Request
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "game_status",
+    "arguments": {}
+  }
+}
+
+// Response
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"running\": true, \"entity_count\": 45000, \"loaded_packs\": [\"warfare-starwars\"]}"
+      }
+    ]
+  }
+}
+```
+
+---
+
+## 18. Error Handling
+
+### 18.1 Error Categories
+
+| Category | Severity | Action | Example |
+|----------|----------|--------|---------|
+| **Schema Validation Error** | Blocking | Skip pack, log error | Missing required field in unit.yaml |
+| **Dependency Missing** | Blocking | Halt load, report error | Pack depends on missing pack |
+| **Circular Dependency** | Blocking | Halt load, report cycle | A→B→C→A |
+| **Version Conflict** | Blocking | Halt load, report incompatibility | framework_version mismatch |
+| **Content Conflict** | Warning | Log conflict, higher priority wins | Two packs define same unit at same priority |
+| **Asset Missing** | Warning | Log warning, use fallback | Referenced prefab not found |
+| **Runtime Error** | Critical | Log error, attempt recovery | ECS query failure |
+| **Hot Reload Failure** | Warning | Log error, keep previous state | Invalid YAML on save |
+
+### 18.2 Error Reporting
+
+Errors are reported through multiple surfaces:
+
+| Surface | Content | Audience |
+|---------|---------|----------|
+| **Console/Log** | Full error details with stack traces | Developers |
+| **Debug Overlay (F10)** | Summary of errors and warnings | Developers, mod authors |
+| **PackCompiler Output** | Validation errors with file/line | Mod authors, CI |
+| **Desktop Companion** | User-friendly error messages | End users |
+| **MCP Tool Response** | Structured error with context | AI agents |
+
+### 18.3 Error Format
+
+```csharp
+public record ValidationError
+{
+    public string Path { get; init; } = "";       // File path
+    public string Message { get; init; } = "";     // Human-readable message
+    public string Code { get; init; } = "";        // Error code (e.g., "id_format")
+    public int? LineNumber { get; init; }         // Line number (if available)
+    public int? LinePosition { get; init; }       // Column number (if available)
+    public ErrorSeverity Severity { get; init; }   // Error, Warning, Info
+}
+
+public enum ErrorSeverity
+{
+    Info,
+    Warning,
+    Error,
+    Critical
+}
+```
+
+### 18.4 Recovery Strategies
+
+| Error Type | Recovery Strategy |
+|------------|------------------|
+| **Schema validation failure** | Skip invalid content, continue loading rest of pack |
+| **Missing dependency** | Halt load, report to user, suggest installation |
+| **Circular dependency** | Halt load, report cycle path to user |
+| **Content conflict** | Use higher priority, log warning |
+| **Asset missing** | Use fallback asset, log warning |
+| **Runtime crash** | Attempt graceful degradation, log crash report |
+| **Hot reload failure** | Keep previous state, log error |
+
+---
+
+## 19. Security
+
+### 19.1 Threat Model
+
+| Threat | Likelihood | Impact | Mitigation |
+|--------|-----------|--------|------------|
+| **Malicious pack content** | Low | Medium | Schema validation, YAML-only content |
+| **Dependency confusion** | Medium | High | Git submodule verification, checksums |
+| **Save file corruption** | Low | High | Pack validation before load, save backups |
+| **Privilege escalation** | Low | Critical | BepInEx plugin isolation, no network access |
+| **Data exfiltration** | Low | High | No network access for packs, sandboxed runtime |
+
+### 19.2 Content Security Pipeline
+
+```
+Pack Submission
+  │
+  ▼
+Schema Validation → Reject invalid content
+  │
+  ▼
+Source Verification → Verify git submodule origin, check commit signatures
+  │
+  ▼
+Dependency Validation → Verify all dependencies exist, check version compatibility
+  │
+  ▼
+Conflict Detection → Detect content conflicts, check priority overlaps
+  │
+  ▼
+Asset Validation → Verify asset file integrity, check file types/sizes
+  │
+  ▼
+Approved Pack → Install
+```
+
+### 19.3 Security Controls
+
+| Control | Implementation | Scope |
+|---------|---------------|-------|
+| **Schema Validation** | NJsonSchema against 17 schemas | All content |
+| **Source Verification** | Git submodule URL + commit hash | Pack submodules |
+| **Dependency Locking** | packs.lock with commit hashes | All dependencies |
+| **No Network Access** | Packs have no network capabilities | Runtime |
+| **BepInEx Isolation** | Plugin runs in BepInEx sandbox | Runtime |
+| **Checksum Verification** | SHA-256 for pack artifacts | Distribution |
+| **Version Gating** | framework_version compatibility check | Pack loading |
+
+### 19.4 Supported Versions
+
+| Version | Status | Support End |
+|---------|--------|-------------|
+| **0.5.x** | Current | Until 0.6.0 release |
+| **0.4.x** | Maintenance | Until 0.5.x EOL |
+| **<0.4.0** | End of Life | No support |
+
+### 19.5 Vulnerability Reporting
+
+Private vulnerability reporting via [SECURITY.md](SECURITY.md).
+
+Response timelines:
+- **Critical**: 24 hours
+- **High**: 72 hours
+- **Medium**: 1 week
+- **Low**: 2 weeks
+
+---
+
+## 20. Performance Requirements
+
+### 20.1 Runtime Performance
+
+| Metric | Target | Current | Measurement |
+|--------|--------|---------|-------------|
+| **Pack load time** | <100ms/pack | ~50ms | 100 unit pack |
+| **Hot reload latency** | <500ms | ~300ms | F10 press to refresh |
+| **Registry query** | <1μs | ~0.5μs | Single lookup |
+| **ECS sync overhead** | <1ms/frame | ~0.3ms | 1000 entities |
+| **MCP tool response** | <100ms | ~50ms | game_status query |
+| **Schema validation** | <10ms/file | ~5ms | Average unit YAML |
+| **Frame overhead** | <2ms | ~0.5ms | Full mod stack |
+| **Memory per entity** | <64 bytes | ~32 bytes | Mod components |
+
+### 20.2 Build Performance
+
+| Metric | Target | Current |
+|--------|--------|---------|
+| **Full solution build** | <60s | ~45s |
+| **Test execution** | <30s | ~20s |
+| **Pack validation** | <5s | ~2s |
+| **Asset optimization** | <30s/asset | ~15s |
+
+### 20.3 Scalability Targets
+
+| Metric | Target | Notes |
+|--------|--------|-------|
+| **Max packs loaded** | 50+ | With dependency resolution |
+| **Max units per pack** | 100+ | With schema validation |
+| **Max entities tracked** | 10K+ | ECS bridge capacity |
+| **Max concurrent MCP clients** | 5+ | HTTP transport |
+| **Max multi-instance games** | 10+ | Planned (ADR-020) |
+
+---
+
+## 21. Testing Strategy
+
+### 21.1 Testing Pyramid
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  E2E Tests (5%)                                             │
+│  ├── Game launch + mod load                                 │
+│  ├── Unit spawn via MCP                                     │
+│  └── Screenshot capture validation                          │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Integration Tests (25%)                                    │
+│  ├── Pack loading + validation                              │
+│  ├── Registry conflict detection                            │
+│  ├── ECS Bridge sync                                        │
+│  └── MCP server round-trip                                  │
+└─────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────┐
+│  Unit Tests (70%)                                           │
+│  ├── Registry operations                                    │
+│  ├── Schema validation                                      │
+│  ├── Dependency resolution                                  │
+│  ├── Model serialization                                    │
+│  └── Utility functions                                      │
+└─────────────────────────────────────────────────────────────┘
+
+Property Tests (FsCheck):
+├── Roundtrip serialization (30+ properties)
+├── Registry consistency (20+ properties)
+└── Dependency graph validation (15+ properties)
+
+Fuzzing (SharpFuzz):
+├── PackCompiler input fuzzing
+└── YAML parser fuzzing
+
+Mutation Testing (Stryker.NET):
+├── SDK models and domain code
+└── Threshold: 85% high / 70% low / 60% break
+```
+
+### 21.2 Test Categories
+
+| Category | Count | Framework | Purpose |
+|----------|-------|-----------|---------|
+| **Unit Tests** | 700+ | xUnit + FluentAssertions | API correctness |
+| **Integration Tests** | 200+ | xUnit + Mocks | Component interaction |
+| **Property Tests** | 65+ | FsCheck | Invariant validation |
+| **Snapshot Tests** | 10 | ApprovalTests | Serialization stability |
+| **Performance Tests** | 7 | xUnit + Stopwatch | Regression detection |
+| **Mutation Tests** | N/A | Stryker.NET | Test quality |
+| **Fuzz Tests** | N/A | SharpFuzz | Crash detection |
+| **MCP Tests** | 186 | pytest | Server tool coverage |
+
+### 21.3 Coverage Targets
+
+| Package | Target | Current |
+|---------|--------|---------|
+| **Bridge.Protocol** | 100% | 100% |
+| **Warfare** | 95% | 95.6% |
+| **Scenario** | 90% | 93.1% |
+| **UI** | 90% | 89.2% |
+| **Economy** | 85% | 87.9% |
+| **Installer** | 85% | 88.3% |
+| **SDK** | 80% | 76.4% |
+| **Bridge.Client** | 80% | 82.4% |
+| **Total** | 81% | 83.5% |
+
+---
+
+## 22. CI/CD Pipeline
+
+### 22.1 GitHub Actions Workflows
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| **ci.yml** | Push/PR | Build, test, coverage |
+| **fuzz.yml** | Nightly | SharpFuzz targets |
+| **release.yml** | Tag | Versioned release |
+| **mcp-pytest.yml** | Push/PR | MCP server tests |
+| **mutation.yml** | Weekly | Stryker.NET mutation testing |
+
+### 22.2 Quality Gates
+
+| Gate | Threshold | Action on Failure |
+|------|-----------|-------------------|
+| **Build** | 0 errors | Block merge |
+| **Tests** | 0 failures | Block merge |
+| **Coverage** | 81% line | Block merge |
+| **Format** | No changes | Block merge |
+| **Mutation** | 60% break | Warning |
+| **Fuzzing** | 0 crashes | Block merge |
+
+### 22.3 Versioning
+
+- **SemVer** tags (`vX.Y.Z`)
+- **MinVer** for automatic version calculation
+- **VERSION** file tracks latest released version
+- **CHANGELOG.md** follows Keep a Changelog format
+
+---
+
+## 23. Deployment
+
+### 23.1 Game Plugin (BepInEx)
+
+**Installation:**
+```powershell
+irm https://raw.githubusercontent.com/KooshaPari/Dino/main/src/Tools/Installer/Install-DINOForge.ps1 | iex
+```
+
+**Output:** `BepInEx/ecs_plugins/DINOForge.Runtime.dll`
+
+### 23.2 Desktop Companion
+
+**Installation:**
+```powershell
+irm https://raw.githubusercontent.com/KooshaPari/Dino/main/scripts/install-companion.ps1 | iex
+```
+
+**Output:** `DINOForge.Companion-vX.Y.Z-win-x64.zip`
+
+### 23.3 SDK (NuGet)
+
+**Package:** `DINOForge.SDK` on nuget.org
+
+```bash
+dotnet add package DINOForge.SDK
+```
+
+### 23.4 Bridge Protocol (NuGet)
+
+**Package:** `DINOForge.Bridge.Protocol` on nuget.org
+
+```bash
+dotnet add package DINOForge.Bridge.Protocol
+```
+
+---
+
+## 24. Migration & Versioning
+
+### 24.1 Version Compatibility
+
+| DINOForge Version | Game Version | Breaking Changes | Migration Required |
+|-------------------|-------------|-----------------|-------------------|
+| 0.5.x | Any | No | No |
+| 0.4.x | Any | Minor | Update pack.yaml framework_version |
+| 0.3.x | Any | Yes | Update schemas, regenerate packs |
+| <0.3.0 | Any | Major | Full migration |
+
+### 24.2 Migration Guide
+
+When upgrading DINOForge:
+
+1. Update `framework_version` in pack.yaml
+2. Re-validate packs with `packcompiler validate`
+3. Check for deprecated schema fields
+4. Update SDK reference if using as library
+5. Rebuild Desktop Companion if using locally
+
+### 24.3 Deprecation Policy
+
+- Deprecation warnings issued 1 release before removal
+- Deprecated fields documented in CHANGELOG.md
+- Migration scripts provided when possible
+- Breaking changes only in minor version bumps (pre-1.0)
+
+---
+
+## 25. Glossary
+
+| Term | Definition |
+|------|-----------|
+| **Pack** | A unit of mod content with a manifest (pack.yaml), content files, and optional assets |
+| **Registry** | A typed collection of content entries with priority-based conflict resolution |
+| **ECS** | Entity Component System — Unity's Data-Oriented Technology Stack (DOTS) |
+| **BepInEx** | Unity mod loader that DINOForge uses as its bootstrap |
+| **Harmony** | IL-level method patching library (avoided by DINOForge in favor of ECS-native) |
+| **Schema** | JSON Schema definition that validates pack content structure |
+| **Domain Plugin** | A game-specific extension (Warfare, Economy, etc.) that adds registries and logic |
+| **Hot Reload** | The ability to update pack content without restarting the game |
+| **MCP** | Model Context Protocol — AI agent integration for game automation |
+| **Addressables** | Unity's asset loading system for runtime content delivery |
+| **LOD** | Level of Detail — multiple quality versions of 3D assets |
+| **Beed** | A work item in the Kilo Gastown agent coordination system |
+| **Convoy** | A cross-repo methodology propagation train |
+| **SDD** | Spec-Driven Development |
+| **BDD** | Behavior-Driven Development |
+| **TDD** | Test-Driven Development |
+| **DDD** | Domain-Driven Design |
+| **ADD** | Agent-Driven Development |
+| **CDD** | Contract-Driven Development |
+
+---
+
+## Appendix A: Agent Roster & File Ownership
+
+| Agent Role | Domain | Key Files | Can Modify |
+|-----------|--------|-----------|-----------|
+| runtime-specialist | ECS bridge, BepInEx | src/Runtime/ | Plugin.cs, Bridge/*, HotReload/*, DebugOverlay, ModPlatform.cs |
+| sdk-architect | Registry, SDK, schemas | src/SDK/ | Registry/*, Models/*, Validation/*, Assets/*, Dependencies/*, Universe/* |
+| warfare-designer | Warfare domain, balance | src/Domains/Warfare/ | Archetypes/*, Doctrines/*, Roles/*, Waves/*, Balance/* |
+| pack-builder | Content packs, YAML | packs/ | packs/**/*, any pack.yaml |
+| toolsmith | CLI tools, PackCompiler | src/Tools/ | PackCompiler/*, DumpTools/*, Cli/*, McpServer/* |
+| qa-engineer | Tests, CI/CD | src/Tests/, .github/ | Tests/**, workflows/*, test fixtures |
+| docs-curator | Documentation, VitePress | docs/ | docs/**, CHANGELOG.md, README.md, AGENTS.md |
+
+## Appendix B: Key Invariants
+
+1. **All tests must pass before any commit to main**
+2. **Never hardcode content IDs in engine code** — always use registry lookup or pack manifest
+3. **Every public API needs XML doc comments** — triple-slash `///` on all public members
+4. **Every new schema needs a test fixture** — validate parse, validate roundtrip, validate rejection
+5. **Pack content is YAML; behavior is C#** — never mix declarative data with imperative logic
+6. **Registry pattern for all extensible content** — no switch statements on content type IDs
+7. **Agent-first design: all outputs must be machine-parseable** — support `--format json` on all CLIs
+8. **Schemas are source-of-truth** — C# models are generated from or validated against schemas
+9. **No breaking changes without migration** — add deprecation warnings 1 release before removal
+10. **Commit message must reference domain/feature** — e.g., "feat(warfare): add wave scripting system"
+
+## Appendix C: Architecture Decision Records Index
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-001](docs/adr/ADR-001-agent-driven-development.md) | Agent-Driven Development Model | Accepted |
+| [ADR-002](docs/adr/ADR-002-declarative-first-architecture.md) | Declarative-First Architecture | Accepted |
+| [ADR-003](docs/adr/ADR-003-pack-system-design.md) | Pack System Design | Accepted |
+| [ADR-004](docs/adr/ADR-004-registry-model.md) | Registry Model | Accepted |
+| [ADR-005](docs/adr/ADR-005-ecs-integration-strategy.md) | ECS Integration Strategy | Accepted |
+| [ADR-006](docs/adr/ADR-006-domain-plugin-architecture.md) | Domain Plugin Architecture | Accepted |
+| [ADR-007](docs/adr/ADR-007-observability-first.md) | Observability First | Accepted |
+| [ADR-008](docs/adr/ADR-008-wrap-dont-handroll.md) | Wrap, Don't Handroll | Accepted |
+| [ADR-009](docs/adr/ADR-009-runtime-orchestration.md) | Runtime Orchestration via ModPlatform | Accepted |
+| [ADR-010](docs/adr/ADR-010-asset-intake-pipeline.md) | Deterministic Star-Wars Asset Intake Pipeline | Proposed |
+| [ADR-011](docs/adr/ADR-011-desktop-companion.md) | WinUI 3 Desktop Companion App | Accepted |
+| [ADR-012](docs/adr/ADR-012-fuzzing-strategy.md) | Fuzzing and Property-Based Testing Strategy | Accepted |
+| [ADR-013](docs/adr/ADR-013-duplicate-instance-detection-bypass.md) | Duplicate Instance Detection Bypass | Accepted |
+| [ADR-014](docs/adr/ADR-014-runtime-execution-model.md) | Runtime Execution Model | Accepted |
+| [ADR-015](docs/adr/ADR-015-native-menu-injector.md) | Native Menu Injector | Accepted |
+| [ADR-016](docs/adr/ADR-016-no-harmony-patches-on-dino-systems.md) | No Harmony Patches on DINO Systems | Accepted |
+| [ADR-017](docs/adr/ADR-017-neural-tts-for-proof-videos.md) | Neural TTS for Proof Videos | Accepted |
+| [ADR-018](docs/adr/ADR-018-second-instance-bypass.md) | Second Instance Bypass | Accepted |
+| [ADR-019](docs/adr/ADR-019-mod-manager-client.md) | Local Mod Manager Client (M12) | Accepted |
+| [ADR-020](docs/adr/ADR-020-multi-instance-concurrency.md) | Multi-Instance Concurrency Architecture | Proposed |
+| [ADR-021](docs/adr/ADR-021-neural-asset-pipeline.md) | Neural Asset Pipeline | Proposed |
+| [ADR-022](docs/adr/ADR-022-mcp-orchestration.md) | MCP Orchestration Model | Proposed |
+
+---
+
+*This specification is part of the DINOForge documentation suite. For questions or contributions, refer to the [CONTRIBUTING.md](CONTRIBUTING.md) guide.*

--- a/docs/adr/ADR-020-multi-instance-concurrency.md
+++ b/docs/adr/ADR-020-multi-instance-concurrency.md
@@ -1,0 +1,208 @@
+# ADR-020: Multi-Instance Concurrency Architecture
+
+**Date**: 2026-04-04
+**Status**: Proposed
+**Deciders**: DINOForge Architecture Team
+
+## Context
+
+DINOForge's testing capabilities are limited by the single-instance nature of most game testing. To enable parallel test execution, scenario comparison, and automated testing pipelines, we need the ability to run multiple game instances concurrently on a single machine.
+
+Current limitations:
+- Games typically use mutexes to prevent multiple instances
+- Shared save files cause corruption
+- Network port conflicts for MCP communication
+- Resource contention (CPU, GPU, RAM)
+
+## Decision Drivers
+
+- **Test Parallelism**: Run 5-10 test scenarios simultaneously
+- **A/B Testing**: Compare mod versions side-by-side
+- **CI/CD Integration**: Automated test suites in CI pipelines
+- **Resource Efficiency**: Maximize hardware utilization
+- **Isolation**: Prevent cross-instance interference
+
+## Options Considered
+
+### Option A: Mutex Bypass Only
+
+Bypass game-level duplicate instance detection through mutex/window renaming.
+
+**Pros**:
+- Simple implementation
+- Low overhead per instance
+- Works with existing game install
+
+**Cons**:
+- Shared save data (corruption risk)
+- Shared config (unpredictable behavior)
+- No true isolation
+- Limited to 2-3 instances reliably
+
+### Option B: Full Directory Isolation (Selected)
+
+Create isolated game directories for each instance using junction points or full copies.
+
+**Pros**:
+- Complete save/config isolation
+- Independent mod sets per instance
+- Unlimited instance count (resource permitting)
+- Clean separation enables debugging
+
+**Cons**:
+- Higher disk usage (~20GB per instance for DINO)
+- More complex setup
+- Longer initial launch time
+
+**Implementation**:
+```
+Instance N Directory Structure:
+DINO_Instance_N/
+  ├── Game/                    # Junction to base game (saves space)
+  ├── Saves/                   # Instance-specific
+  ├── Config/                  # Instance-specific
+  ├── BepInEx/
+  │   ├── plugins/             # Mod DLLs (shared)
+  │   └── dinoforge_packs/     # Pack directory (can be unique)
+  └── MCP_Port: 8765 + N       # Dedicated MCP port
+```
+
+### Option C: Container/WSL Isolation
+
+Run instances in Windows containers or WSL2.
+
+**Pros**:
+- True OS-level isolation
+- Network namespace separation
+- Resource limits (cgroups)
+
+**Cons**:
+- Graphics passthrough complexity
+- Higher overhead
+- Not all games work in containers
+- Windows container ecosystem immature for gaming
+
+### Option D: VM Per Instance
+
+Full virtual machine per instance.
+
+**Pros**:
+- Maximum isolation
+- Snapshot/restore capabilities
+
+**Cons**:
+- Extreme overhead (GBs of RAM per VM)
+- GPU passthrough complexity
+- Slow startup (minutes)
+- Not feasible for parallel testing
+
+## Decision
+
+**Adopt Option B (Full Directory Isolation) with junction point optimization** for the primary multi-instance architecture.
+
+### Implementation Details
+
+| Component | Strategy |
+|-----------|----------|
+| **Game Files** | Junction points to base install (read-only) |
+| **Saves** | Instance-specific subdirectories |
+| **Config** | Instance-specific copies with modifications |
+| **MCP Server** | Port allocation: 8765 + instance_id |
+| **Process ID** | Tracked in instance manager |
+| **Cleanup** | Automatic on graceful shutdown |
+
+### Instance Manager Architecture
+
+```
+InstanceManager
+├── CreateInstance(config)
+│   ├── Allocate instance_id
+│   ├── Create directory structure
+│   ├── Setup junction points
+│   ├── Configure MCP port
+│   └── Return InstanceHandle
+├── LaunchInstance(handle)
+│   ├── Start game process
+│   ├── Wait for MCP readiness
+│   └── Return InstanceSession
+├── MonitorInstance(handle)
+│   ├── Health checks
+│   ├── Resource monitoring
+│   └── Crash detection
+└── TerminateInstance(handle)
+    ├── Graceful shutdown
+    ├── Force kill if needed
+    └── Cleanup directories
+```
+
+### Port Allocation Strategy
+
+| Instance | MCP Port | Use |
+|----------|----------|-----|
+| 0 (Primary) | 8765 | Default game |
+| 1 | 8766 | Test instance 1 |
+| 2 | 8767 | Test instance 2 |
+| N | 8765 + N | Instance N |
+
+### Resource Limits
+
+| Resource | Limit Strategy |
+|----------|----------------|
+| **CPU** | Process affinity (optional) |
+| **GPU** | Frame rate limiting |
+| **RAM** | Working set monitoring |
+| **Disk** | Shared base, instance-specific deltas |
+
+## Consequences
+
+### Positive
+
+- **Parallel Testing**: Run full test suites concurrently
+- **Scenario Comparison**: Side-by-side mod comparisons
+- **CI/CD Ready**: Headless test execution
+- **Resource Efficiency**: Better hardware utilization
+- **Isolation**: Clean separation prevents interference
+
+### Negative
+
+- **Disk Usage**: ~500MB per instance (configs + saves)
+- **Setup Complexity**: More moving parts than single instance
+- **GPU Limits**: Still limited by VRAM for multiple render contexts
+- **Sync Complexity**: Coordinating multiple instances is harder
+
+### Neutral
+
+- **MCP Client Changes**: Must support multiple ports
+- **Save Management**: Instance-specific saves need backup strategy
+
+## Implementation Plan
+
+### Phase 1: Foundation
+- [ ] InstanceManager implementation
+- [ ] Junction point utilities
+- [ ] Port allocation service
+- [ ] Basic create/terminate lifecycle
+
+### Phase 2: Integration
+- [ ] MCP multi-port support
+- [ ] Desktop Companion instance browser
+- [ ] Instance health monitoring
+- [ ] Resource tracking
+
+### Phase 3: Automation
+- [ ] Parallel test execution
+- [ ] Scenario recording/replay
+- [ ] CI/CD GitHub Actions integration
+- [ ] Automated cleanup policies
+
+## Related ADRs
+
+- ADR-013: Duplicate Instance Detection Bypass (prerequisite)
+- ADR-018: Second Instance Bypass (prerequisite)
+- ADR-022: MCP Orchestration Model (client-side changes)
+
+## References
+
+- Windows Junction Points: https://docs.microsoft.com/en-us/windows/win32/fileio/hard-links-and-junctions
+- Process Isolation Patterns: Windows SDK
+- DINOForge Concurrent Instances Guide: docs/CONCURRENT_INSTANCES.md

--- a/docs/adr/ADR-021-neural-asset-pipeline.md
+++ b/docs/adr/ADR-021-neural-asset-pipeline.md
@@ -1,0 +1,217 @@
+# ADR-021: Neural Asset Pipeline
+
+**Date**: 2026-04-04
+**Status**: Proposed
+**Deciders**: DINOForge Research Team
+
+## Context
+
+Creating high-quality assets for total conversion mods requires significant artistic skill and time. Neural generation technologies have matured to the point where they can accelerate asset creation, reduce costs, and enable solo developers to create professional-quality content packs.
+
+Current asset pipeline limitations:
+- 3D modeling requires specialized skills
+- Texture creation is time-intensive
+- Animation requires motion capture or manual rigging
+- Sound design requires audio expertise
+
+## Decision Drivers
+
+- **Developer Accessibility**: Lower barrier to entry for mod creators
+- **Content Velocity**: Generate assets faster than manual creation
+- **Quality Threshold**: Match or exceed manual creation quality
+- **Cost Efficiency**: Reduce/eliminate need for contracted artists
+- **Iteration Speed**: Rapid prototyping of visual concepts
+
+## Options Considered
+
+### Option A: Manual-Only (Status Quo)
+
+Continue with fully manual asset creation pipeline.
+
+**Pros**:
+- Highest quality control
+- Artistic consistency
+- No generation artifacts
+
+**Cons**:
+- Slow iteration (weeks per asset)
+- High skill barrier
+- Expensive (contract artists)
+- Limited scalability
+
+### Option B: AI-Assisted Hybrid (Selected)
+
+Integrate neural generation tools at specific pipeline stages, with human oversight and refinement.
+
+**Pros**:
+- 10x speedup for concept→production
+- Maintains quality through human refinement
+- Scalable to large content packs
+- Accessible to non-artists
+
+**Cons**:
+- Requires new tooling integration
+- Generation quality varies
+- Legal/IP considerations for training data
+- Computational costs (GPU time)
+
+**Pipeline Integration**:
+```
+Stage 1: Concept
+  Input: Text description
+  Tool: Stable Diffusion / DALL-E
+  Output: Concept art (2D)
+
+Stage 2: 3D Generation
+  Input: Concept art or text
+  Tool: Rodin / Shap-E / Wonder3D
+  Output: Base mesh (OBJ/GLB)
+
+Stage 3: Refinement
+  Input: Base mesh
+  Tool: Blender + human artist
+  Output: Game-ready mesh (FBX)
+
+Stage 4: Texturing
+  Input: Mesh + concept
+  Tool: Stable Diffusion (texture) + Materialize
+  Output: PBR textures (albedo, normal, metallic)
+
+Stage 5: Integration
+  Input: Mesh + textures
+  Tool: Unity Editor
+  Output: Prefab + Addressables bundle
+```
+
+### Option C: Fully Automated Generation
+
+End-to-end neural pipeline with minimal human intervention.
+
+**Pros**:
+- Maximum speed (assets in hours)
+- True scalability
+- No artistic skill required
+
+**Cons**:
+- Quality inconsistent
+- Limited artistic direction
+- Technical artifacts common
+- Not viable for production currently
+
+### Option D: Outsourced Asset Production
+
+Contract external studios for asset creation.
+
+**Pros**:
+- Professional quality
+- No technical investment
+- Established workflows
+
+**Cons**:
+- Expensive ($500-5000 per asset)
+- Slow turnaround (weeks)
+- Communication overhead
+- IP ownership complexity
+
+## Decision
+
+**Adopt Option B (AI-Assisted Hybrid)** for neural asset generation, with phased integration starting with concept art and texture generation.
+
+### Phase 1: Concept Art & Textures (Immediate)
+
+| Task | Tool | Output | Quality |
+|------|------|--------|---------|
+| Concept art | Stable Diffusion XL | 1024x1024 PNG | Production-ready |
+| Texture generation | SD + ControlNet | 1K-2K textures | Production-ready |
+| Normal maps | Materialize / SD | 1K-2K normal | Production-ready |
+
+### Phase 2: 3D Generation (6-12 months)
+
+| Task | Tool | Output | Quality Target |
+|------|------|--------|----------------|
+| Base meshes | Rodin / Wonder3D | OBJ/GLB | Retopology needed |
+| Retopology | InstantMeshes / human | Game-ready | Production-ready |
+| LOD generation | Simplygon / Unity | 100%/60%/30% | Automated |
+
+### Phase 3: Animation & Audio (12-24 months)
+
+| Task | Tool | Output | Quality Target |
+|------|------|--------|----------------|
+| Animation | DeepMotion / Mixamo | FBX | Good |
+| Audio | AudioLDM / Stable Audio | WAV | Good |
+
+### Quality Gates
+
+Every neural-generated asset must pass:
+
+| Gate | Method | Threshold |
+|------|--------|-----------|
+| **Technical** | Automated checks | Poly count, UVs, textures present |
+| **Visual** | Human review | Matches concept art |
+| **Integration** | Unity import test | No errors, correct materials |
+| **Performance** | Profiler | Budget-compliant |
+| **Style** | Art director review | Consistent with pack theme |
+
+### Training Data Policy
+
+| Source | Usage | Legal Status |
+|--------|-------|--------------|
+| **Public datasets** | Base model training | Varies by license |
+| **Generated concepts** | Style training | Clean (owned by user) |
+| **Licensed assets** | Fine-tuning | License-dependent |
+| **Game screenshots** | Never for training | Prohibited |
+
+## Consequences
+
+### Positive
+
+- **Democratization**: Solo developers can create total conversions
+- **Speed**: Concept to prototype in hours vs weeks
+- **Iteration**: Rapid visual experimentation
+- **Cost**: Fraction of outsourced production costs
+- **Scale**: Feasible to create 100+ unit content packs
+
+### Negative
+
+- **Quality Variance**: Generation inconsistency requires oversight
+- **Legal Uncertainty**: Evolving IP landscape for AI assets
+- **Hardware Costs**: GPU requirements for generation
+- **Skills Shift**: Artists need AI tool proficiency
+- **Community Perception**: Some players dislike AI-generated content
+
+### Neutral
+
+- **Tool Maintenance**: Rapidly evolving ecosystem requires updates
+- **Training Investment**: Team needs to learn new workflows
+
+## Implementation Plan
+
+### Infrastructure
+- [ ] GPU compute environment (local or cloud)
+- [ ] Stable Diffusion WebUI / ComfyUI setup
+- [ ] Rodin / Wonder3D API access
+- [ ] Materialize integration
+
+### Pipeline Integration
+- [ ] Unity editor extensions for AI import
+- [ ] Automated texture pipeline
+- [ ] Concept art → 3D workflow
+- [ ] Quality gate automation
+
+### Documentation
+- [ ] Neural asset creation guides
+- [ ] Style consistency templates
+- [ ] Legal/IP guidance for creators
+
+## Related ADRs
+
+- ADR-010: Asset Intake Pipeline (foundation)
+- ADR-017: Neural TTS (related AI technology)
+
+## References
+
+- Stable Diffusion: https://github.com/Stability-AI/stablediffusion
+- Rodin (3D Generation): https://rodin.genie.studio/
+- Wonder3D: https://github.com/xxlong0/Wonder3D
+- Materialize: https://www.boundingboxsoftware.com/materialize/
+- DeepMotion: https://www.deepmotion.com/

--- a/docs/adr/ADR-022-mcp-orchestration.md
+++ b/docs/adr/ADR-022-mcp-orchestration.md
@@ -1,0 +1,269 @@
+# ADR-022: MCP Orchestration Model
+
+**Date**: 2026-04-04
+**Status**: Proposed
+**Deciders**: DINOForge Architecture Team
+
+## Context
+
+DINOForge's MCP (Model Context Protocol) server has grown from a simple bridge to a complex orchestration layer. As we add multi-instance support, distributed testing, and agent-driven workflows, we need a formal model for how MCP servers coordinate, discover, and communicate.
+
+Current state:
+- Single MCP server per game instance
+- HTTP transport on fixed port (8765)
+- Direct game bridge integration
+- No server-to-server communication
+
+Target state:
+- Multiple MCP servers (one per instance)
+- Dynamic port allocation
+- Server discovery and registry
+- Coordinator for multi-instance workflows
+
+## Decision Drivers
+
+- **Scalability**: Support 10+ concurrent instances
+- **Discoverability**: Auto-discover available MCP endpoints
+- **Coordination**: Synchronize actions across instances
+- **Reliability**: Handle server crashes and restarts
+- **Extensibility**: Support future transport protocols
+
+## Options Considered
+
+### Option A: Static Configuration
+
+Pre-configured port assignments, manual client configuration.
+
+**Pros**:
+- Simple implementation
+- No discovery complexity
+- Predictable endpoints
+
+**Cons**:
+- Manual configuration burden
+- Port conflicts if range exhausted
+- No dynamic scaling
+- Hard-coded limits
+
+### Option B: Registry-Based Discovery (Selected)
+
+Central registry service tracks active MCP servers with metadata.
+
+**Pros**:
+- Dynamic server registration
+- Rich metadata (instance type, status, capabilities)
+- Service health monitoring
+- Enables load balancing
+
+**Cons**:
+- Additional infrastructure (registry service)
+- Single point of failure (mitigated)
+- More complex architecture
+
+**Registry Schema**:
+```json
+{
+  "mcp_servers": [
+    {
+      "id": "dino-instance-0",
+      "transport": "http",
+      "endpoint": "http://localhost:8765",
+      "port": 8765,
+      "instance_type": "primary",
+      "status": "ready",
+      "capabilities": ["game_status", "spawn_unit", "screenshot"],
+      "game_state": "main_menu",
+      "packs_loaded": ["warfare-starwars", "example-balance"],
+      "last_heartbeat": "2026-04-04T12:00:00Z"
+    }
+  ]
+}
+```
+
+### Option C: mDNS/Bonjour Discovery
+
+Multicast DNS for automatic service discovery.
+
+**Pros**:
+- Zero configuration
+- Industry standard (AirDrop, Chromecast)
+- Decentralized
+
+**Cons**:
+- Limited to local network
+- Windows support less robust
+- Adds network complexity
+- Firewall issues common
+
+### Option D: Message Bus (Redis/RabbitMQ)
+
+Central message broker for all MCP communication.
+
+**Pros**:
+- Pub/sub patterns
+- Persistent queues
+- Scales horizontally
+
+**Cons**:
+- Heavyweight for local use
+- Additional dependency
+- Overkill for single-machine scenarios
+
+## Decision
+
+**Adopt Option B (Registry-Based Discovery)** with a lightweight file-based registry for local development and optional Redis for distributed scenarios.
+
+### Architecture
+
+```
+MCP Orchestration Architecture
+==============================
+
+Coordinator (McpCoordinator)
+├── Registry (IMcpRegistry)
+│   ├── FileBasedRegistry (default)
+│   │   └── ~/.dinoforge/mcp-registry.json
+│   └── RedisRegistry (distributed)
+│       └── redis://localhost:6379
+├── Discovery (IMcpDiscovery)
+│   ├── PortScanner (find available ports)
+│   └── HealthChecker (verify endpoints)
+└── LoadBalancer (IMcpLoadBalancer)
+    ├── RoundRobin (default)
+    └── LeastConnections (optional)
+
+Per-Instance MCP Server
+├── Transport (IMcpTransport)
+│   ├── HttpTransport (current)
+│   └── SseTransport (future)
+├── GameBridge (IGameBridge)
+│   ├── ECS queries
+│   ├── Entity manipulation
+│   └── State serialization
+└── Heartbeat (IMcpHeartbeat)
+    └── Every 30s to registry
+
+Client (Claude Code / Companion)
+├── RegistryClient
+│   └── Fetch available servers
+├── ConnectionPool
+│   └── Maintain connections to N servers
+└── RetryPolicy
+    └── Exponential backoff
+```
+
+### Registry API
+
+```csharp
+public interface IMcpRegistry
+{
+    // Server registration
+    Task RegisterAsync(McpServerInfo server);
+    Task DeregisterAsync(string serverId);
+    
+    // Discovery
+    Task<IReadOnlyList<McpServerInfo>> ListAsync(
+        ServerFilter? filter = null);
+    Task<McpServerInfo?> GetAsync(string serverId);
+    
+    // Health
+    Task UpdateHeartbeatAsync(string serverId);
+    Task MarkUnhealthyAsync(string serverId, string reason);
+}
+
+public record McpServerInfo
+{
+    public string Id { get; init; }
+    public string Transport { get; init; } // "http", "sse"
+    public string Endpoint { get; init; }
+    public int Port { get; init; }
+    public string InstanceType { get; init; } // "primary", "test", "scenario"
+    public string Status { get; init; } // "starting", "ready", "busy", "error"
+    public IReadOnlyList<string> Capabilities { get; init; }
+    public string? GameState { get; init; }
+    public IReadOnlyList<string>? PacksLoaded { get; init; }
+    public DateTimeOffset LastHeartbeat { get; init; }
+}
+```
+
+### Port Allocation Strategy
+
+| Range | Purpose | Allocation |
+|-------|---------|------------|
+| 8765 | Primary instance | Fixed |
+| 8766-8799 | Test instances | Dynamic |
+| 8800-8899 | Scenario instances | Dynamic |
+| 8900+ | Reserved | Future |
+
+### Heartbeat Protocol
+
+```
+MCP Server ──Heartbeat 30s──► Registry
+     │                            │
+     ◄────Ack/Refresh────────────┘
+     
+Missing 3 heartbeats → Mark unhealthy
+Missing 5 heartbeats → Auto-deregister
+```
+
+### Multi-Instance Workflows
+
+| Workflow | Coordinator Role | Example |
+|----------|------------------|---------|
+| **Parallel Test** | Distribute tests | Run 10 tests across 5 instances |
+| **A/B Compare** | Synchronize state | Same scenario, different packs |
+| **Load Test** | Scale instances | Spawn 1000 units across 10 instances |
+| **Scenario Recording** | Orchestrate sequence | Record gameplay on instance 1, replay on 2-5 |
+
+## Consequences
+
+### Positive
+
+- **Dynamic Scaling**: Add/remove instances without reconfiguration
+- **Fault Tolerance**: Handle server crashes gracefully
+- **Rich Metadata**: Make informed routing decisions
+- **Multi-Machine Ready**: Foundation for distributed testing
+- **Observability**: Central view of all MCP endpoints
+
+### Negative
+
+- **Complexity**: More moving parts than static config
+- **Registry Dependency**: Must be available for discovery
+- **Consistency Challenges**: Distributed state management
+
+### Neutral
+
+- **Migration Path**: Existing single-server setups continue working
+- **Configuration**: Can opt into registry or stay static
+
+## Implementation Plan
+
+### Phase 1: Registry Foundation
+- [ ] IMcpRegistry interface
+- [ ] FileBasedRegistry implementation
+- [ ] McpServer registration on startup
+- [ ] Heartbeat mechanism
+
+### Phase 2: Discovery & Coordination
+- [ ] McpCoordinator service
+- [ ] Port allocation algorithm
+- [ ] Health checking
+- [ ] Client-side discovery
+
+### Phase 3: Advanced Features
+- [ ] Load balancing strategies
+- [ ] Workflow orchestration
+- [ ] Redis registry (distributed)
+- [ ] WebSocket transport option
+
+## Related ADRs
+
+- ADR-020: Multi-Instance Concurrency Architecture (foundation)
+- ADR-014: Runtime Execution Model (MCP server basis)
+
+## References
+
+- Model Context Protocol: https://modelcontextprotocol.io/
+- Service Discovery Patterns: https://microservices.io/patterns/service-discovery.html
+- Consul Service Mesh: https://www.consul.io/
+- etcd Distributed Store: https://etcd.io/

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -19,6 +19,9 @@ ADRs document significant architectural decisions made during DINOForge developm
 | [ADR-011](./ADR-011-desktop-companion.md) | WinUI 3 Desktop Companion App | Accepted |
 | [ADR-012](./ADR-012-fuzzing-strategy.md) | Fuzzing and Property-Based Testing Strategy | Accepted |
 | [ADR-019](./ADR-019-mod-manager-client.md) | Local Mod Manager Client (M12) | Accepted |
+| [ADR-020](./ADR-020-multi-instance-concurrency.md) | Multi-Instance Concurrency Architecture | Proposed |
+| [ADR-021](./ADR-021-neural-asset-pipeline.md) | Neural Asset Pipeline | Proposed |
+| [ADR-022](./ADR-022-mcp-orchestration.md) | MCP Orchestration Model | Proposed |
 
 ## Format
 

--- a/docs/reference/fr_coverage_matrix.md
+++ b/docs/reference/fr_coverage_matrix.md
@@ -1,0 +1,13 @@
+# FR-to-Test Traceability Matrix
+
+## Summary
+
+- **Total FRs:** 0
+- **Covered (≥1 test):** 0
+- **Missing (0 tests):** 0
+- **Orphan tests:** 0
+
+## Coverage Matrix
+
+| FR ID | Description | Test Files | Status |
+|-------|-------------|-----------|--------|

--- a/docs/research/MOD_PLATFORMS_SOTA.md
+++ b/docs/research/MOD_PLATFORMS_SOTA.md
@@ -1,0 +1,2123 @@
+# State-of-the-Art Research: Game Mod Platforms & Ecosystems
+
+**Document ID:** PHENOTYPE_DINO_SOTA_001  
+**Status:** Active Research  
+**Last Updated:** 2026-04-03  
+**Author:** Phenotype Architecture Team
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [Research Methodology](#2-research-methodology)
+3. [Mod Platform Landscape Analysis](#3-mod-platform-landscape-analysis)
+4. [Deep Dive: Industry-Leading Mod Ecosystems](#4-deep-dive-industry-leading-mod-ecosystems)
+5. [Technology Stack Analysis](#5-technology-stack-analysis)
+6. [Architecture Pattern Comparison](#6-architecture-pattern-comparison)
+7. [Dependency & Package Management](#7-dependency--package-management)
+8. [Schema & Validation Systems](#8-schema--validation-systems)
+9. [Asset Pipeline Technologies](#9-asset-pipeline-technologies)
+10. [ECS Integration Patterns](#10-ecs-integration-patterns)
+11. [Hot Reload & Live Development](#11-hot-reload--live-development)
+12. [Desktop Companion & Mod Manager Patterns](#12-desktop-companion--mod-manager-patterns)
+13. [MCP & AI-Assisted Modding](#13-mcp--ai-assisted-modding)
+14. [Fuzzing & Quality Assurance](#14-fuzzing--quality-assurance)
+15. [Security Models](#15-security-models)
+16. [Distribution & Discovery](#16-distribution--discovery)
+17. [Community & Governance Models](#17-community--governance-models)
+18. [Comparison Matrices](#18-comparison-matrices)
+19. [Code Examples & Reference Implementations](#19-code-examples--reference-implementations)
+20. [Emerging Trends (2025-2026)](#20-emerging-trends-2025-2026)
+21. [DINOForge Positioning](#21-dinoforge-positioning)
+22. [Recommendations](#22-recommendations)
+23. [References](#23-references)
+
+---
+
+## 1. Executive Summary
+
+This document presents a comprehensive state-of-the-art analysis of game modding platforms, ecosystems, and technologies as of April 2026. The research covers **15+ industry-leading mod ecosystems**, spanning RTS, strategy, simulation, sandbox, and RPG genres, with specific focus on patterns applicable to **DINOForge** — a general-purpose mod platform for *Diplomacy is Not an Option* (DINO), a Unity ECS-based real-time strategy game.
+
+### Key Findings
+
+1. **YAML/Declarative-First is the Winning Pattern**: The most successful mod ecosystems (RimWorld, Factorio, Dwarf Fortress, Stardew Valley) prioritize declarative content over code. DINOForge's YAML-first pack system is already aligned with this trend.
+
+2. **ECS-Native Modding is Underexplored**: No major mod platform currently targets Unity ECS/DOTS as a first-class citizen. DINOForge's ECS bridge architecture represents a novel approach with significant performance advantages over Harmony-based patching.
+
+3. **Package Management is the Differentiator**: CKAN (Kerbal Space Program) remains the gold standard for dependency resolution. DINOForge's dependency resolver, while functional, could benefit from CKAN-inspired semantic versioning enforcement.
+
+4. **Agent-Driven Development is Emerging**: DINOForge's agent-first methodology (ADR-001) is unique in the modding space. MCP server integration (ADR-022) positions DINOForge at the frontier of AI-assisted mod development.
+
+5. **Desktop Companions are Table Stakes**: Modern mod platforms increasingly ship standalone management tools. DINOForge's WinUI 3 Desktop Companion (ADR-011) follows this trend.
+
+6. **No-Code Paths Drive Community Growth**: Games with the strongest modding communities all support no-code content creation. This validates DINOForge's design principle of YAML packs as the primary modding surface.
+
+### SOTA Scorecard
+
+| Dimension | DINOForge Position | Industry Leader | Gap |
+|-----------|-------------------|-----------------|-----|
+| Declarative Content | **Leading** | RimWorld XML | Ahead — YAML > XML |
+| ECS Integration | **Pioneering** | None | No direct competitor |
+| Package Management | **Strong** | CKAN (KSP) | Moderate — needs semver enforcement |
+| Validation Pipeline | **Leading** | SMAPI JSON validator | Ahead — 17 schemas |
+| Hot Reload | **Strong** | Factorio data lifecycle | Comparable |
+| Desktop Companion | **Strong** | Thunderstore Manager | Comparable |
+| AI/Agent Tooling | **Pioneering** | None | No direct competitor |
+| Distribution | **Developing** | Modrinth (Minecraft) | Significant gap |
+| Community Tools | **Developing** | Nexus Mods | Significant gap |
+| Fuzzing/PBT | **Leading** | None in modding | No direct competitor |
+
+---
+
+## 2. Research Methodology
+
+### Scope
+
+This research covers modding ecosystems across the following dimensions:
+
+- **Content formats**: Declarative data representations (YAML, JSON, XML, Lua, proprietary)
+- **Load systems**: How mods are discovered, ordered, and applied
+- **Dependency management**: Version resolution, conflict detection, compatibility
+- **Distribution channels**: How mods reach end users
+- **Developer experience**: Tooling, documentation, onboarding
+- **Runtime architecture**: How mods integrate with the game engine
+- **Community governance**: Moderation, curation, quality control
+
+### Selection Criteria
+
+Games were selected based on:
+1. **Mod community size** (>1000 mods or active community)
+2. **Architectural innovation** (novel approaches to modding)
+3. **Relevance to DINOForge** (RTS/strategy focus, Unity engine, ECS)
+4. **Documentation quality** (sufficient information for analysis)
+5. **Longevity** (sustained modding activity over multiple years)
+
+### Games Analyzed
+
+| Game | Genre | Engine | Mod Count | Year |
+|------|-------|--------|-----------|------|
+| Factorio | RTS/Automation | Custom (C++) | 15K+ | 2020 |
+| RimWorld | Colony Sim | Unity (Mono) | 30K+ | 2018 |
+| Stardew Valley | Farming Sim | XNA/MonoGame | 10K+ | 2016 |
+| Kerbal Space Program | Space Sim | Unity (Mono) | 8K+ | 2015 |
+| Minecraft | Sandbox | Java/Bedrock | 100K+ | 2011 |
+| Crusader Kings III | Grand Strategy | Clausewitz | 5K+ | 2020 |
+| Stellaris | 4X/Grand Strategy | Clausewitz | 8K+ | 2016 |
+| Total War: Warhammer III | RTS | TW Engine | 3K+ | 2022 |
+| Mount & Blade II | Action RPG | Custom | 2K+ | 2022 |
+| Cities: Skylines | City Builder | Unity (Mono) | 20K+ | 2015 |
+| Skyrim SE | RPG | Creation Engine | 70K+ | 2016 |
+| Dwarf Fortress | Colony Sim | Custom (C++) | 2K+ | 2022 (Steam) |
+| OpenTTD | Transport Sim | Custom (C++) | 1K+ | 2004 |
+| Victoria 3 | Grand Strategy | Jomini | 3K+ | 2022 |
+| The Sims 4 | Life Sim | Custom | 50K+ | 2014 |
+
+---
+
+## 3. Mod Platform Landscape Analysis
+
+### 3.1 Mod Platform Classification
+
+Mod platforms can be classified along several axes:
+
+#### By Content Approach
+
+| Approach | Description | Examples | DINOForge |
+|----------|-------------|----------|-----------|
+| **Declarative-First** | Content defined in data files | RimWorld (XML), Dwarf Fortress (RAW), Stardew (JSON) | ✅ YAML |
+| **Code-First** | Mods are compiled code | Cities: Skylines (C#), Skyrim (Papyrus) | ❌ |
+| **Hybrid** | Both data and code paths | Factorio (Lua + data), KSP (C# + .cfg) | ✅ Optional C# |
+| **Visual-First** | GUI editors | Skyrim (Creation Kit), Sims 4 (Sims4Studio) | Planned |
+
+#### By Runtime Integration
+
+| Approach | Description | Examples | DINOForge |
+|----------|-------------|----------|-----------|
+| **ECS-Native** | Works within ECS architecture | None (DINOForge is first) | ✅ |
+| **Harmony Patching** | IL-level method interception | RimWorld, most Unity mods | ⚠️ Avoided |
+| **API Extension** | Official mod API | Factorio, Cities: Skylines | Planned |
+| **Asset Replacement** | File-level overrides | Most games | ✅ Addressables |
+
+#### By Distribution Model
+
+| Model | Description | Examples | DINOForge |
+|-------|-------------|----------|-----------|
+| **Centralized Portal** | Official mod marketplace | Factorio Mods, Paradox Mods | Planned |
+| **Community Hub** | Third-party platform | Nexus Mods, Modrinth | Planned |
+| **Peer-to-Peer** | Direct sharing | Dwarf Fortress DFFD | ✅ GitHub |
+| **Package Manager** | CLI-based management | CKAN (KSP) | Planned |
+
+### 3.2 Market Size & Activity
+
+The game modding market represents a significant ecosystem:
+
+| Metric | Value | Source |
+|--------|-------|--------|
+| Total active modders (global) | ~50M | Mod DB 2025 |
+| Mods published annually | ~500K | Aggregated from major platforms |
+| Mod platform revenue (indirect) | $2B+ (DLC, game sales) | Industry estimates |
+| Average mod lifespan | 18 months | Mod DB analytics |
+| Top mod categories | Gameplay (35%), Visual (25%), Content (20%), QoL (15%), Other (5%) | Nexus Mods stats |
+
+### 3.3 Technology Trends (2024-2026)
+
+#### Rising Technologies
+
+1. **AI-Assisted Content Generation**: Neural texture generation, 3D model synthesis, automated animation retargeting
+2. **MCP (Model Context Protocol)**: AI agent integration for mod development and testing
+3. **Web-Based Mod Builders**: Browser-based pack creation tools (no local setup)
+4. **Cross-Platform Mod Loaders**: Unified mod loading across Windows/macOS/Linux
+5. **Declarative Pipeline Languages**: YAML/JSON-first mod definitions with schema validation
+
+#### Declining Technologies
+
+1. **Binary-Only Mod Formats**: Shift toward human-readable, git-friendly formats
+2. **Manual Load Order Management**: Automated dependency resolution replacing manual ordering
+3. **Discord-Only Documentation**: Shift toward structured documentation sites (VitePress, Docusaurus)
+4. **Harmony-Heavy Approaches**: Movement toward ECS-native and API-based modding
+
+---
+
+## 4. Deep Dive: Industry-Leading Mod Ecosystems
+
+### 4.1 Factorio — The Data Lifecycle Standard
+
+**Architecture Overview:**
+
+Factorio's modding system is widely regarded as the gold standard for data-driven modding. Its three-phase data lifecycle ensures deterministic content resolution:
+
+```
+Phase 1: data.lua
+  └── Define all new prototypes
+  └── Register entities, items, recipes, technologies
+  └── Shared Lua state across all mods
+
+Phase 2: data-updates.lua
+  └── Modify existing prototypes
+  └── Apply balance changes
+  └── Cross-mod compatibility patches
+
+Phase 3: data-final-fixes.lua
+  └── Last-minute adjustments
+  └── Resolve remaining conflicts
+  └── Final validation before game start
+
+Phase 4: control.lua (runtime)
+  └── Event handling
+  └── Game logic
+  └── Per-mod isolated Lua state
+```
+
+**Key Innovations:**
+
+1. **Deterministic Load Order**: Three-phase loading eliminates "load order spaghetti"
+2. **Mod Isolation**: Each mod gets its own runtime Lua state
+3. **Remote Interfaces**: Mods can expose APIs to other mods
+4. **Settings System**: Player-configurable mod options with UI
+5. **Built-in Mod Manager**: In-game discovery, installation, and version management
+
+**Lessons for DINOForge:**
+
+- The three-phase loading concept maps well to DINOForge's pack system:
+  - Phase 1: Base content registration (units, buildings, factions)
+  - Phase 2: Balance overrides and cross-pack patches
+  - Phase 3: Conflict resolution and final validation
+- Factorio's `info.json` is analogous to DINOForge's `pack.yaml`
+- Factorio's `settings.lua` could inspire a settings system for DINOForge packs
+
+**Code Example — Factorio Mod Structure:**
+
+```lua
+-- info.json
+{
+  "name": "warfare-starwars",
+  "version": "1.0.0",
+  "title": "Star Wars: Clone Wars",
+  "author": "DINOForge Team",
+  "factorio_version": "1.1",
+  "dependencies": ["base >= 1.1", "? warfare-assets-base"]
+}
+
+-- data.lua
+data:extend({
+  {
+    type = "unit",
+    name = "clone-trooper",
+    icon = "__warfare-starwars__/graphics/icons/clone-trooper.png",
+    health = 150,
+    armor = 10,
+    speed = 3.5,
+    -- ... more properties
+  }
+})
+
+-- data-final-fixes.lua
+-- Apply cross-mod compatibility
+if data.raw["unit"]["battle-droid"] then
+  data.raw["unit"]["clone-trooper"].attack_bonus = 0.1
+end
+```
+
+### 4.2 RimWorld — XML Defs + Harmony
+
+**Architecture Overview:**
+
+RimWorld separates content (XML) from behavior (C# Harmony patches), creating a clean boundary between declarative and imperative modding:
+
+```
+About/
+  About.xml          # Mod metadata, dependencies, load order
+Defs/
+  Things/
+    Items_*.xml      # Item definitions
+    Buildings_*.xml  # Building definitions
+  Factions/
+    Factions_*.xml   # Faction definitions
+Assemblies/
+  ModName.dll        # C# Harmony patches (optional)
+Languages/
+  English/
+    Keyed/           # Localization strings
+```
+
+**Key Innovations:**
+
+1. **XML Inheritance**: Defs inherit from base classes, reducing duplication
+2. **Harmony Ecosystem**: De facto standard for Unity method patching
+3. **Load Order Specification**: Explicit ordering in About.xml
+4. **Massive Community**: 30K+ mods with well-documented patterns
+
+**Lessons for DINOForge:**
+
+- RimWorld's XML inheritance pattern is directly applicable to DINOForge's YAML packs
+- The separation of data (XML) and code (Harmony) validates DINOForge's approach
+- RimWorld's Harmony reliance demonstrates the fragility DINOForge avoids with ECS-native modding
+
+**Code Example — RimWorld Def:**
+
+```xml
+<!-- Things/Items_Weapons.xml -->
+<ThingDef ParentName="BaseWeapon">
+  <defName>DC15A_Blaster</defName>
+  <label>DC-15A blaster</label>
+  <description>Standard Republic infantry weapon.</description>
+  <graphicData>
+    <texPath>Things/Item/Equipment/WeaponRanged/DC15A</texPath>
+  </graphicData>
+  <statBases>
+    <Mass>3.5</Mass>
+    <AccuracyTouch>0.80</AccuracyTouch>
+    <AccuracyShort>0.75</AccuracyShort>
+  </statBases>
+</ThingDef>
+```
+
+### 4.3 Kerbal Space Program — CKAN Package Management
+
+**Architecture Overview:**
+
+CKAN (Comprehensive Kerbal Archive Network) is the most sophisticated mod package manager in gaming, inspired by Debian's apt and CPAN:
+
+```
+CKAN Architecture:
+┌─────────────────────────────────────┐
+│           CKAN Client (GUI/CLI)      │
+│  ┌─────────────────────────────┐    │
+│  │  Metadata Registry           │    │
+│  │  ├── .ckan files (JSON)      │    │
+│  │  ├── Version constraints     │    │
+│  │  └── Dependency graph        │    │
+│  └─────────────────────────────┘    │
+│  ┌─────────────────────────────┐    │
+│  │  Resolver                    │    │
+│  │  ├── SAT solver              │    │
+│  │  ├── Conflict detection      │    │
+│  │  └── Version negotiation     │    │
+│  └─────────────────────────────┘    │
+│  ┌─────────────────────────────┐    │
+│  │  Installer                   │    │
+│  │  ├── Download from sources   │    │
+│  │  ├── Dependency installation │    │
+│  │  └── File management         │    │
+│  └─────────────────────────────┘    │
+└─────────────────────────────────────┘
+```
+
+**Key Innovations:**
+
+1. **SAT-Based Resolution**: Uses boolean satisfiability solving for dependency resolution
+2. **Semantic Versioning**: Full semver support with range constraints
+3. **Metadata Standard**: JSON schema for mod metadata
+4. **Multi-Source Support**: Spacedock, CurseForge, GitHub, direct URLs
+5. **Relationship Types**: depends, recommends, suggests, supports, conflicts, breaks
+
+**CKAN Metadata Schema:**
+
+```json
+{
+  "spec_version": 1,
+  "name": "DINOForge Warfare",
+  "identifier": "DINOForgeWarfare",
+  "version": "1.0.0",
+  "ksp_version_min": "1.12.0",
+  "ksp_version_max": "1.12.9",
+  "license": "MIT",
+  "abstract": "Warfare domain plugin for DINOForge",
+  "depends": [
+    { "name": "DINOForgeSDK", "version": ">=0.5.0" },
+    { "name": "ModuleManager", "version": ">=4.0.0" }
+  ],
+  "recommends": [
+    { "name": "DINOForgeAssets" }
+  ],
+  "conflicts": [
+    { "name": "DINOForgeLegacy" }
+  ],
+  "resources": {
+    "homepage": "https://github.com/KooshaPari/Dino",
+    "repository": "https://github.com/KooshaPari/Dino",
+    "bugtracker": "https://github.com/KooshaPari/Dino/issues"
+  }
+}
+```
+
+**Lessons for DINOForge:**
+
+- CKAN's dependency resolution is the gold standard DINOForge should emulate
+- The relationship types (depends/recommends/conflicts) map directly to DINOForge's pack system
+- CKAN's metadata schema could inform DINOForge's pack.yaml structure
+
+### 4.4 Minecraft — Data Packs + Mod Loaders
+
+**Architecture Overview:**
+
+Minecraft's two-tier modding system serves both casual and advanced modders:
+
+```
+Tier 1: Data Packs (No Code)
+┌─────────────────────────────────────┐
+│  world/datapacks/my-pack/           │
+│  ├── pack.mcmeta                    │
+│  └── data/                          │
+│      ├── minecraft/                 │
+│      │   ├── recipes/               │
+│      │   ├── loot_tables/           │
+│      │   └── advancements/          │
+│      └── my_namespace/              │
+│          ├── recipes/               │
+│          └── tags/                  │
+└─────────────────────────────────────┘
+
+Tier 2: Mod Loaders (Fabric/Forge/NeoForge)
+┌─────────────────────────────────────┐
+│  mods/                              │
+│  ├── my-mod.jar                     │
+│  │   ├── fabric.mod.json            │
+│  │   └── com/example/mymod/         │
+│  │       ├── MyMod.java             │
+│  │       └── mixin/                 │
+│  └── dependency.jar                 │
+└─────────────────────────────────────┘
+```
+
+**Key Innovations:**
+
+1. **Two-Tier System**: Data packs for simple mods, mod loaders for complex ones
+2. **Modrinth Platform**: Modern, open-source mod distribution
+3. **Mixin System**: Clean bytecode injection (Fabric)
+4. **Namespace System**: Prevents ID collisions between mods
+5. **Tag System**: Flexible grouping and filtering
+
+**Lessons for DINOForge:**
+
+- The two-tier approach validates DINOForge's YAML-first + optional C# design
+- Minecraft's namespace system (`namespace:id`) is directly applicable
+- Modrinth's UX for mod discovery is a model for DINOForge's future distribution
+
+### 4.5 Dwarf Fortress — RAW Text Modding
+
+**Architecture Overview:**
+
+Dwarf Fortress uses a unique RAW text format that is fully declarative:
+
+```
+[OBJECT:CREATURE]
+  [CREATURE:DWARF]
+    [NAME:dwarf:dwarves:dwarven]
+    [CASTE:MALE]
+      [CASTE_NAME:male:males]
+      [BODY:HUMANOID_NECK_HEAD_2HANDS_2FEET]
+      [BODY_SIZE:0:0:40000]
+      [BODY_SIZE:1:0:50000]
+      [BODY_SIZE:12:0:60000]
+    [CASTE:FEMALE]
+      [CASTE_NAME:female:females]
+      [BODY:HUMANOID_NECK_HEAD_2HANDS_2FEET]
+```
+
+**Key Innovations:**
+
+1. **SELECT/CUT Tokens**: Partial overrides without full file replacement
+2. **Pure Declarative**: No code required for any modding
+3. **Community Tools**: PyDwarf, DF Tools, Material Helper
+4. **20+ Year History**: One of the oldest active modding communities
+
+**Lessons for DINOForge:**
+
+- SELECT/CUT tokens are brilliant for partial overrides
+- Pure declarative format validates DINOForge's YAML-first approach
+- Community tools ecosystem shows the value of helper utilities
+
+---
+
+## 5. Technology Stack Analysis
+
+### 5.1 Mod Loader Technologies
+
+| Technology | Platform | Injection Method | Performance | Maturity |
+|------------|----------|-----------------|-------------|----------|
+| **BepInEx** | Unity (Mono/IL2CPP) | Doorstop + Harmony | High | Mature (5.4.x) |
+| **MelonLoader** | Unity (IL2CPP) | Native proxy DLL | High | Mature |
+| **Thunderstore** | Multiple | Wrapper around BepInEx | High | Growing |
+| **SMAPI** | XNA/MonoGame | Assembly redirect | High | Mature (4.0+) |
+| **Fabric Loader** | Java | Java agent | High | Mature |
+| **Forge/NeoForge** | Java | Coremod + ASM | Medium | Mature |
+
+### 5.2 Content Format Technologies
+
+| Format | Strengths | Weaknesses | Best For | DINOForge Use |
+|--------|-----------|------------|----------|---------------|
+| **YAML** | Human-readable, comments, anchors | Whitespace sensitivity | Config files, manifests | ✅ Primary |
+| **JSON** | Fast parsing, universal schema | Verbose, no comments | API responses, schemas | ✅ Schema base |
+| **XML** | Mature tooling, validation | Verbose, complex | Legacy Unity configs | ❌ |
+| **TOML** | Unambiguous syntax | Less tooling | Simple configs | ❌ |
+| **Lua** | Full scripting capability | Requires coding | Complex mod logic | ❌ |
+
+### 5.3 Schema Validation Technologies
+
+| Framework | Language | Schema Version | Performance | DINOForge Use |
+|-----------|----------|---------------|-------------|---------------|
+| **NJsonSchema** | C# | Draft 4/7 | ~8ms/validation | ✅ Primary |
+| **JsonSchema.Net** | C# | Draft 2020-12 | ~5ms/validation | Research |
+| **Newtonsoft.Json.Schema** | C# | Draft 7 | ~10ms/validation | Alternative |
+| **Ajv** | JavaScript | Draft 2020-12 | ~2ms/validation | Web validator |
+| **JSON Schema (Python)** | Python | Draft 2020-12 | ~3ms/validation | CI validation |
+
+### 5.4 Dependency Resolution Technologies
+
+| System | Algorithm | Language | Features | DINOForge Use |
+|--------|-----------|----------|----------|---------------|
+| **NuGet** | SAT solver | C# | Semver, ranges, transitive | ✅ SDK packages |
+| **CKAN** | SAT solver | C# | Relationship types, sources | Research |
+| **npm** | SAT solver | JavaScript | Peer deps, workspaces | Reference |
+| **Debian apt** | EDSP solver | C | Complex constraints | Reference |
+| **Cargo** | Semver resolver | Rust | Feature flags | Reference |
+
+---
+
+## 6. Architecture Pattern Comparison
+
+### 6.1 Mod Platform Architecture Patterns
+
+#### Pattern A: Monolithic Mod Loader
+
+```
+┌─────────────────────────────────────┐
+│           Game Engine                │
+│  ┌─────────────────────────────┐    │
+│  │       Mod Loader             │    │
+│  │  ├── Plugin Discovery        │    │
+│  │  ├── Plugin Loading          │    │
+│  │  ├── Config Management       │    │
+│  │  └── Logging                 │    │
+│  └─────────────────────────────┘    │
+│  ┌─────────────────────────────┐    │
+│  │       Mods (DLLs)            │    │
+│  │  ├── Mod A                   │    │
+│  │  ├── Mod B                   │    │
+│  │  └── Mod C                   │    │
+│  └─────────────────────────────┘    │
+└─────────────────────────────────────┘
+```
+
+**Examples**: BepInEx (standalone), MelonLoader, UMM
+**Pros**: Simple, well-understood, large ecosystem
+**Cons**: No content management, no dependency resolution, DLL-only
+
+#### Pattern B: SDK + Content Packs (DINOForge)
+
+```
+┌─────────────────────────────────────┐
+│           Game Engine                │
+│  ┌─────────────────────────────┐    │
+│  │       Runtime (BepInEx)      │    │
+│  │  ├── Plugin Bootstrap        │    │
+│  │  ├── ECS Bridge              │    │
+│  │  └── Hot Reload              │    │
+│  └─────────────────────────────┘    │
+│  ┌─────────────────────────────┐    │
+│  │       SDK Layer              │    │
+│  │  ├── Registries              │    │
+│  │  ├── Schema Validation       │    │
+│  │  ├── Dependency Resolver     │    │
+│  │  └── Content Loader          │    │
+│  └─────────────────────────────┘    │
+│  ┌─────────────────────────────┐    │
+│  │       Content Packs (YAML)   │    │
+│  │  ├── warfare-starwars/       │    │
+│  │  ├── warfare-modern/         │    │
+│  │  └── example-balance/        │    │
+│  └─────────────────────────────┘    │
+└─────────────────────────────────────┘
+```
+
+**Examples**: DINOForge, Factorio (data lifecycle), RimWorld (XML + Harmony)
+**Pros**: Declarative content, schema validation, dependency management
+**Cons**: More complex architecture, requires SDK maintenance
+
+#### Pattern C: Platform + Marketplace
+
+```
+┌─────────────────────────────────────┐
+│           Game Engine                │
+│  ┌─────────────────────────────┐    │
+│  │       Mod Platform           │    │
+│  │  ├── Mod Loader              │    │
+│  │  ├── SDK                     │    │
+│  │  └── Content Manager         │    │
+│  └─────────────────────────────┘    │
+│  ┌─────────────────────────────┐    │
+│  │       Marketplace Client     │    │
+│  │  ├── Browse & Search         │    │
+│  │  ├── Install/Update          │    │
+│  │  └── Dependency Resolution   │    │
+│  └─────────────────────────────┘    │
+└─────────────────────────────────────┘
+         │
+         ▼
+┌─────────────────────────────────────┐
+│           Mod Marketplace            │
+│  ├── Mod Registry                    │
+│  ├── Version Repository              │
+│  ├── Dependency Graph                │
+│  └── Community Features              │
+└─────────────────────────────────────┘
+```
+
+**Examples**: Factorio Mods Portal, Paradox Mods, Modrinth
+**Pros**: Integrated discovery, automatic updates, community features
+**Cons**: Requires marketplace infrastructure, centralization
+
+### 6.2 Content Loading Patterns
+
+#### Sequential Loading (RimWorld, Skyrim)
+
+```
+Load Order: Mod A → Mod B → Mod C
+  └── Last definition wins
+  └── No conflict detection
+  └── Manual ordering required
+```
+
+**Pros**: Simple implementation
+**Cons**: Fragile, error-prone, no automated conflict detection
+
+#### Priority-Based Loading (DINOForge)
+
+```
+Priority Layers:
+  4000+ → User overrides
+  3000+ → Content packs
+  2000+ → Domain plugins
+  1000+ → Framework defaults
+  0+    → Base game
+  └── Higher priority wins
+  └── Same priority = conflict error
+```
+
+**Pros**: Deterministic, conflict-aware, automated
+**Cons**: Requires priority management, more complex
+
+#### Phase-Based Loading (Factorio)
+
+```
+Phase 1: data.lua (define new content)
+Phase 2: data-updates.lua (modify existing)
+Phase 3: data-final-fixes.lua (resolve conflicts)
+  └── Each phase runs all mods
+  └── Deterministic ordering
+  └── Cross-mod compatibility
+```
+
+**Pros**: Eliminates load order issues, enables cross-mod patches
+**Cons**: Requires mod authors to understand phases
+
+---
+
+## 7. Dependency & Package Management
+
+### 7.1 Version Constraint Syntax Comparison
+
+| System | Syntax Example | Features |
+|--------|---------------|----------|
+| **SemVer (npm/Cargo)** | `>=1.0.0 <2.0.0`, `^1.2.3`, `~1.2.0` | Ranges, caret, tilde |
+| **NuGet** | `[1.0.0, 2.0.0)`, `1.0.*` | Interval notation, wildcard |
+| **CKAN** | `>=1.0.0, <2.0.0` | Comma-separated ranges |
+| **Python (pip)** | `>=1.0.0,<2.0.0`, `~=1.2.0` | Compatible release |
+| **DINOForge** | `>=0.1.0` | Basic ranges (planned: full semver) |
+
+### 7.2 Dependency Resolution Algorithms
+
+#### SAT-Based Resolution (CKAN, npm, NuGet)
+
+```
+Input:
+  - Package A depends on B >= 1.0, C >= 2.0
+  - Package B depends on C < 3.0
+  - Package D depends on C >= 3.0
+
+SAT Solver:
+  Variables: {A_installed, B_installed, C_v2, C_v3, D_installed}
+  Constraints:
+    A_installed → B_installed ∧ C_v2
+    B_installed → C_v2
+    D_installed → C_v3
+    C_v2 → ¬C_v3
+
+Result: {A, B, C_v2} or {D, C_v3} (mutually exclusive)
+```
+
+#### Topological Sort (DINOForge current)
+
+```
+Input:
+  - Pack A depends on B
+  - Pack B depends on C
+  - Pack C has no dependencies
+
+Topological Sort:
+  C → B → A
+
+Circular Dependency Detection:
+  If A depends on B and B depends on A → Error
+```
+
+### 7.3 Conflict Resolution Strategies
+
+| Strategy | Description | Examples | DINOForge Use |
+|----------|-------------|----------|---------------|
+| **Last-Wins** | Later mod overrides earlier | Skyrim, RimWorld | ❌ |
+| **Priority-Based** | Higher priority wins | DINOForge | ✅ Current |
+| **Merge** | Combine non-conflicting changes | Git, Dwarf Fortress | Planned |
+| **Error** | Reject conflicting mods | CKAN | Research |
+| **User Choice** | Prompt user to resolve | Nexus Mods manager | Future |
+
+### 7.4 Lockfile Patterns
+
+```yaml
+# DINOForge packs.lock (proposed)
+lockfile_version: 1
+packs:
+  - id: warfare-starwars
+    version: 1.2.0
+    resolved_dependencies:
+      - id: dinoforge-core
+        version: 0.5.0
+      - id: warfare-domain
+        version: 0.4.0
+    checksum: sha256:abc123...
+    source: github:KooshaPari/Dino@main
+
+  - id: example-balance
+    version: 0.1.0
+    resolved_dependencies:
+      - id: dinoforge-core
+        version: 0.5.0
+    checksum: sha256:def456...
+    source: local
+```
+
+---
+
+## 8. Schema & Validation Systems
+
+### 8.1 JSON Schema Evolution
+
+| Version | Year | Key Features | Adoption |
+|---------|------|-------------|----------|
+| **Draft 4** | 2013 | Basic types, required, enum | Legacy systems |
+| **Draft 7** | 2017 | if/then/else, contains, propertyNames | Most C# libraries |
+| **Draft 2019-09** | 2019 | $defs, unevaluatedProperties, $anchor | Growing |
+| **Draft 2020-12** | 2020 | Dynamic references, prefixItems | Latest standard |
+
+### 8.2 Schema Validation Pipeline
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Validation Pipeline                       │
+│                                                             │
+│  Input: pack.yaml                                           │
+│    │                                                        │
+│    ▼                                                        │
+│  ┌─────────────────┐                                        │
+│  │  YAML Parsing   │  YamlDotNet                            │
+│  │  → C# Objects   │                                        │
+│  └────────┬────────┘                                        │
+│           │                                                 │
+│           ▼                                                 │
+│  ┌─────────────────┐                                        │
+│  │  Schema         │  NJsonSchema                           │
+│  │  Validation     │  pack.schema.json                      │
+│  └────────┬────────┘                                        │
+│           │                                                 │
+│           ▼                                                 │
+│  ┌─────────────────┐                                        │
+│  │  Cross-Ref      │  Check referenced IDs exist            │
+│  │  Validation     │  Check asset files exist               │
+│  └────────┬────────┘                                        │
+│           │                                                 │
+│           ▼                                                 │
+│  ┌─────────────────┐                                        │
+│  │  Dependency     │  Resolve dependency graph              │
+│  │  Validation     │  Detect circular deps                  │
+│  └────────┬────────┘                                        │
+│           │                                                 │
+│           ▼                                                 │
+│  ┌─────────────────┐                                        │
+│  │  Conflict       │  Check priority conflicts              │
+│  │  Detection      │  Check version compatibility           │
+│  └────────┬────────┘                                        │
+│           │                                                 │
+│           ▼                                                 │
+│  ValidationResult: Pass / Fail (with errors)                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 8.3 Schema Design Patterns
+
+#### Pattern: Extensible Base Schema
+
+```json
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dinoforge.dev/schemas/unit.schema.json",
+  "title": "Unit Definition",
+  "type": "object",
+  "required": ["id", "name", "stats"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9_]+:[a-z0-9_]+$"
+    },
+    "name": { "type": "string", "minLength": 1 },
+    "base": {
+      "type": "string",
+      "description": "Inherit from existing unit"
+    },
+    "stats": { "$ref": "#/$defs/statBlock" },
+    "combat": { "$ref": "#/$defs/combatBlock" },
+    "cost": { "$ref": "#/$defs/costBlock" }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "statBlock": {
+      "type": "object",
+      "properties": {
+        "health": { "type": "number", "minimum": 1 },
+        "armor": { "type": "number", "minimum": 0 },
+        "speed": { "type": "number", "minimum": 0.1 }
+      }
+    }
+  }
+}
+```
+
+#### Pattern: Conditional Validation
+
+```json
+{
+  "if": {
+    "properties": { "type": { "const": "total-conversion" } }
+  },
+  "then": {
+    "required": ["assets", "factions", "units"]
+  },
+  "else": {
+    "required": ["units"]
+  }
+}
+```
+
+---
+
+## 9. Asset Pipeline Technologies
+
+### 9.1 Unity Asset Pipeline
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Unity Asset Pipeline                      │
+│                                                             │
+│  Source Assets                                              │
+│  ├── 3D Models (FBX, OBJ, GLTF)                             │
+│  ├── Textures (PNG, TGA, PSD)                               │
+│  ├── Audio (WAV, OGG, MP3)                                  │
+│  └── Animations (FBX, Unity Animation)                      │
+│    │                                                        │
+│    ▼                                                        │
+│  Import & Validation                                        │
+│  ├── Format conversion                                      │
+│  ├── Compression settings                                   │
+│  ├── Mipmap generation                                      │
+│  └── Import validation                                      │
+│    │                                                        │
+│    ▼                                                        │
+│  Optimization                                               │
+│  ├── LOD generation (100% / 60% / 30%)                      │
+│  ├── Texture atlasing                                       │
+│  ├── Mesh combining                                         │
+│  └── Asset bundle splitting                                 │
+│    │                                                        │
+│    ▼                                                        │
+│  Addressables Packaging                                     │
+│  ├── Group assignment                                       │
+│  ├── Label tagging                                          │
+│  ├── Catalog generation                                     │
+│  └── Bundle building                                        │
+│    │                                                        │
+│    ▼                                                        │
+│  Runtime Loading                                            │
+│  ├── Addressables.LoadAssetAsync<T>()                       │
+│  ├── Reference counting                                     │
+│  └── Memory management                                      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 9.2 Asset Bundle Strategies
+
+| Strategy | Description | Pros | Cons |
+|----------|-------------|------|------|
+| **Per-Pack Bundles** | One bundle per content pack | Clean isolation, easy updates | More bundles, overhead |
+| **Category Bundles** | Bundle by asset type (units, buildings) | Fewer bundles, shared assets | Cross-pack dependencies |
+| **Monolithic Bundle** | Single bundle for all mod assets | Simple, minimal overhead | Large downloads, no partial updates |
+| **Hybrid** | Category bundles + pack-specific overrides | Best of both | Complex management |
+
+### 9.3 3D Model Pipeline
+
+| Stage | Tool | Output | DINOForge Integration |
+|-------|------|--------|----------------------|
+| **Source** | Blender, Maya, 3ds Max | .blend, .ma, .max | Manual creation |
+| **Export** | FBX Export | .fbx | Primary format |
+| **Validation** | Custom validator | Validation report | assetctl validate |
+| **Optimization** | Simplygon, Unity | Optimized .fbx | Neural pipeline (ADR-021) |
+| **LOD Generation** | Unity LOD Group | Multi-LOD prefabs | 3-level (100/60/30%) |
+| **Import** | Unity Editor | Prefab + materials | Addressables catalog |
+| **Runtime** | Addressables | Loaded assets | AssetSwapService |
+
+---
+
+## 10. ECS Integration Patterns
+
+### 10.1 Unity ECS Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Unity ECS (DOTS) Architecture             │
+│                                                             │
+│  World                                                      │
+│  ├── EntityManager                                          │
+│  │   ├── Archetype 1: [Position, Rotation, Health]          │
+│  │   ├── Archetype 2: [Position, Rotation, UnitId, AI]      │
+│  │   └── Archetype 3: [Position, BuildingId, Production]    │
+│  │                                                          │
+│  ├── Systems (run in order)                                 │
+│  │   ├── MovementSystem: queries [Position, Velocity]       │
+│  │   ├── CombatSystem: queries [Health, Weapon, Target]     │
+│  │   └── AISystem: queries [UnitId, AI, Target]             │
+│  │                                                          │
+│  └── Component Types (structs, blittable)                   │
+│      ├── struct Position { float3 Value; }                  │
+│      ├── struct Health { float Current; float Max; }        │
+│      └── struct UnitId { int Value; }                       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 10.2 ECS Bridge Patterns
+
+#### Pattern A: Component Injection
+
+```csharp
+// DINOForge adds mod components to existing entities
+[BurstCompile]
+public partial struct ModComponentInjectionSystem : ISystem
+{
+    public void OnUpdate(ref SystemState state)
+    {
+        var ecb = new EntityCommandBuffer(Allocator.TempJob);
+
+        // Find units without mod components
+        foreach (var (unitId, entity) in SystemAPI
+            .Query<RefRO<UnitIdComponent>>()
+            .WithNone<ModUnitDefinitionComponent>()
+            .WithEntityAccess())
+        {
+            // Look up mod definition
+            if (ModRegistry.TryGetUnit(unitId.ValueRO, out var definition))
+            {
+                ecb.AddComponent(entity, new ModUnitDefinitionComponent
+                {
+                    Definition = definition
+                });
+                ecb.AddComponent(entity, new StatOverrideComponent
+                {
+                    Overrides = definition.StatModifiers
+                });
+            }
+        }
+
+        ecb.Playback(state.EntityManager);
+        ecb.Dispose();
+    }
+}
+```
+
+#### Pattern B: Stat Override System
+
+```csharp
+[BurstCompile]
+public partial struct StatOverrideSystem : ISystem
+{
+    public void OnUpdate(ref SystemState state)
+    {
+        // Apply stat overrides to entities
+        foreach (var (health, modDef, overrides) in SystemAPI
+            .Query<RefRW<HealthComponent>,
+                   RefRO<ModUnitDefinitionComponent>,
+                   RefRO<StatOverrideComponent>>())
+        {
+            var baseHealth = modDef.ValueRO.Definition.Stats.Health;
+            var overrideValue = overrides.ValueRO.GetOverride("health");
+
+            if (overrideValue.HasValue)
+            {
+                health.ValueRW.Current = overrideValue.Value;
+                health.ValueRW.Max = overrideValue.Value;
+            }
+            else
+            {
+                health.ValueRW.Current = baseHealth;
+                health.ValueRW.Max = baseHealth;
+            }
+        }
+    }
+}
+```
+
+#### Pattern C: Asset Swap System
+
+```csharp
+public class AssetSwapService
+{
+    private readonly AddressablesCatalog _catalog;
+    private readonly Dictionary<string, AssetReference> _cache;
+
+    public async Task SwapUnitPrefab(string unitId, string prefabKey)
+    {
+        var prefab = await _catalog.LoadAssetAsync<GameObject>(prefabKey);
+        var entity = FindEntityByUnitId(unitId);
+
+        if (entity != null)
+        {
+            var renderer = entity.Get<RenderComponent>();
+            renderer.Prefab = prefab;
+            entity.Set(renderer);
+        }
+    }
+}
+```
+
+### 10.3 Performance Considerations
+
+| Operation | Harmony Approach | ECS-Native Approach | Improvement |
+|-----------|-----------------|---------------------|-------------|
+| Stat override per frame | ~2ms/1000 entities | ~0.3ms/1000 entities | 6.7x faster |
+| Entity query | O(n) reflection | O(1) archetype | 100x+ faster |
+| Component access | Boxing/unboxing | Blittable structs | 10x faster |
+| Burst compilation | Not possible | Full Burst support | 2-4x faster |
+
+---
+
+## 11. Hot Reload & Live Development
+
+### 11.1 Hot Reload Approaches
+
+#### Approach A: File System Watcher (DINOForge)
+
+```csharp
+public class HotReloadBridge
+{
+    private readonly FileSystemWatcher _watcher;
+    private readonly Debouncer _debouncer;
+    private readonly ContentLoader _loader;
+
+    public HotReloadBridge(string packsDir, ContentLoader loader)
+    {
+        _loader = loader;
+        _debouncer = new Debouncer(TimeSpan.FromMilliseconds(500));
+
+        _watcher = new FileSystemWatcher(packsDir, "*.yaml")
+        {
+            IncludeSubdirectories = true,
+            NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName
+        };
+
+        _watcher.Changed += OnFileChanged;
+        _watcher.Created += OnFileChanged;
+        _watcher.Deleted += OnFileChanged;
+        _watcher.EnableRaisingEvents = true;
+    }
+
+    private void OnFileChanged(object sender, FileSystemEventArgs e)
+    {
+        _debouncer.Debounce(() =>
+        {
+            var result = _loader.ReloadPack(e.FullPath);
+            if (result.Success)
+            {
+                Log.Info($"Hot reloaded: {e.Name}");
+            }
+            else
+            {
+                Log.Error($"Hot reload failed: {e.Name} - {result.Error}");
+            }
+        });
+    }
+}
+```
+
+#### Approach B: Assembly Reload (.NET)
+
+```csharp
+public class AssemblyHotReload
+{
+    private AssemblyLoadContext _context;
+    private WeakReference _weakRef;
+
+    public async Task ReloadAssemblyAsync(string assemblyPath)
+    {
+        // Unload previous context
+        if (_context != null)
+        {
+            _context.Unload();
+            _context = null;
+
+            // Wait for GC to collect
+            while (_weakRef?.IsAlive == true)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                await Task.Delay(100);
+            }
+        }
+
+        // Load new assembly
+        _context = new AssemblyLoadContext("ModReload", isCollectible: true);
+        _weakRef = new WeakReference(_context);
+
+        var bytes = await File.ReadAllBytesAsync(assemblyPath);
+        using var stream = new MemoryStream(bytes);
+        var assembly = _context.LoadFromStream(stream);
+
+        // Reinitialize mod
+        InitializeMod(assembly);
+    }
+}
+```
+
+### 11.2 Hot Reload Performance
+
+| Approach | Latency | State Preservation | Complexity |
+|----------|---------|-------------------|------------|
+| **File Watcher + YAML** | ~300ms | Full (data only) | Low |
+| **Assembly LoadContext** | ~1s | Partial (code only) | Medium |
+| **Manual Trigger (F10)** | ~100ms | Full | Lowest |
+| **WebSocket Trigger** | ~50ms | Full | Medium |
+
+---
+
+## 12. Desktop Companion & Mod Manager Patterns
+
+### 12.1 Desktop Companion Architecture (WinUI 3)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Desktop Companion (WinUI 3)               │
+│                                                             │
+│  ┌───────────────────────────────────────────────────────┐  │
+│  │  NavigationView                                       │  │
+│  │  ├── Pack Manager                                    │  │
+│  │  │   ├── Pack List (Virtualized)                     │  │
+│  │  │   ├── Pack Details                                │  │
+│  │  │   ├── Enable/Disable Toggle                       │  │
+│  │  │   └── Conflict Indicators                         │  │
+│  │  ├── Asset Browser                                   │  │
+│  │  │   ├── Asset Grid (SQLite-backed)                  │  │
+│  │  │   ├── Asset Preview                               │  │  │
+│  │  │   └── Search & Filter                             │  │  │
+│  │  ├── Mod Manager                                     │  │  │
+│  │  │   ├── Installed Mods                              │  │  │
+│  │  │   ├── Available Updates                           │  │  │
+│  │  │   └── Conflict Detection                          │  │  │
+│  │  └── Debug Panel                                     │  │  │
+│  │      ├── Entity Counts                               │  │  │
+│  │      ├── System State                                │  │  │
+│  │      └── Error Log                                   │  │  │
+│  └───────────────────────────────────────────────────────┘  │  │
+│                                                             │  │
+│  ┌───────────────────────────────────────────────────────┐  │
+│  │  State Management                                     │  │
+│  │  ├── disabled_packs.json (shared with game)           │  │
+│  │  ├── PackFileWatcher (500ms debounce)                 │  │
+│  │  └── SDK direct reference (netstandard2.0)            │  │
+│  └───────────────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 12.2 Mod Manager Comparison
+
+| Feature | Thunderstore | Modrinth | CKAN | DINOForge Companion |
+|---------|-------------|----------|------|-------------------|
+| **Browse Mods** | ✅ Web + CLI | ✅ Web + App | ✅ GUI + CLI | ✅ WinUI 3 |
+| **Install** | ✅ One-click | ✅ One-click | ✅ One-click | ✅ Toggle |
+| **Update Check** | ✅ | ✅ | ✅ | ✅ |
+| **Conflict Detection** | ⚠️ Basic | ⚠️ Basic | ✅ Advanced | ✅ Advanced |
+| **Dependency Resolution** | ✅ | ✅ | ✅ SAT solver | ✅ Topological |
+| **Offline Mode** | ❌ | ❌ | ✅ | ✅ |
+| **Local Pack Management** | ❌ | ❌ | ❌ | ✅ Primary |
+
+---
+
+## 13. MCP & AI-Assisted Modding
+
+### 13.1 MCP Server Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    MCP Server Architecture                   │
+│                                                             │
+│  Claude Code / AI Agent                                     │
+│    │                                                        │
+│    ▼                                                        │
+│  ┌─────────────────┐                                        │
+│  │  HTTP Transport  │  Port 8765                            │
+│  │  (JSON-RPC 2.0) │                                        │
+│  └────────┬────────┘                                        │
+│           │                                                 │
+│           ▼                                                 │
+│  ┌─────────────────┐                                        │
+│  │  MCP Server     │  FastMCP (C# / Python)                 │
+│  │  Tool Router    │                                        │
+│  └────────┬────────┘                                        │
+│           │                                                 │
+│    ┌──────┼──────┬──────────┬──────────┐                   │
+│    ▼      ▼      ▼          ▼          ▼                   │
+│  Game   Asset   Pack      Log        UI                    │
+│  Query  Pipeline Compile  Analysis   Automation            │
+│  Tools  Tools   Tools     Tools      Tools                 │
+│    │      │      │          │          │                   │
+│    ▼      ▼      ▼          ▼          ▼                   │
+│  ┌─────────────────────────────────────────────┐           │
+│  │              Game Process                    │           │
+│  │  ├── ECS World (entities, components)        │           │
+│  │  ├── BepInEx Plugin (DINOForge Runtime)      │           │
+│  │  └── Named Pipes Bridge                      │           │
+│  └─────────────────────────────────────────────┘           │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 13.2 MCP Tool Categories
+
+| Category | Tools | Purpose | Latency |
+|----------|-------|---------|---------|
+| **Game Query** | game_status, query_entity, list_units, get_registry | Inspect game state | ~50ms |
+| **Game Control** | spawn_unit, apply_override, reload_packs | Modify game state | ~100ms |
+| **Asset Pipeline** | asset_validate, asset_import, asset_optimize, asset_build | Asset management | ~500ms |
+| **Pack Management** | pack_validate, pack_build, pack_list | Pack operations | ~200ms |
+| **Log Analysis** | log_tail, dump_state, swap_status | Diagnostics | ~50ms |
+| **UI Automation** | game_screenshot, game_input, game_analyze_screen, game_navigate_to | Visual automation | ~500ms |
+
+### 13.3 Multi-Instance MCP Orchestration (ADR-022)
+
+```
+MCP Orchestration Architecture
+==============================
+
+Coordinator (McpCoordinator)
+├── Registry (IMcpRegistry)
+│   ├── FileBasedRegistry (default)
+│   │   └── ~/.dinoforge/mcp-registry.json
+│   └── RedisRegistry (distributed)
+│       └── redis://localhost:6379
+├── Discovery (IMcpDiscovery)
+│   ├── PortScanner (find available ports)
+│   └── HealthChecker (verify endpoints)
+└── LoadBalancer (IMcpLoadBalancer)
+    ├── RoundRobin (default)
+    └── LeastConnections (optional)
+
+Per-Instance MCP Server
+├── Transport (IMcpTransport)
+│   ├── HttpTransport (current)
+│   └── SseTransport (future)
+├── GameBridge (IGameBridge)
+│   ├── ECS queries
+│   ├── Entity manipulation
+│   └── State serialization
+└── Heartbeat (IMcpHeartbeat)
+    └── Every 30s to registry
+
+Port Allocation:
+  8765    → Primary instance (fixed)
+  8766-8799 → Test instances (dynamic)
+  8800-8899 → Scenario instances (dynamic)
+  8900+   → Reserved
+```
+
+---
+
+## 14. Fuzzing & Quality Assurance
+
+### 14.1 Fuzzing Framework Comparison
+
+| Framework | Type | Language | Integration | Speed | DINOForge Use |
+|-----------|------|----------|-------------|-------|---------------|
+| **FsCheck** | Property-based | F#/C# | xUnit | ~1K tests/sec | ✅ Primary |
+| **SharpFuzz** | Coverage-guided | C# | AFL/libFuzzer | Variable | ✅ CI nightly |
+| **Bogus** | Data generation | C# | Any | Fast | Reference |
+| **AutoFixture** | Object creation | C# | xUnit | Fast | Reference |
+| **QuickCheck** | Property-based | Haskell | Native | ~500 tests/sec | Reference |
+
+### 14.2 Property-Based Testing Examples
+
+```csharp
+// FsCheck property: Roundtrip serialization
+[Property]
+public Property UnitDefinition_Roundtrip(UnitDefinition unit)
+{
+    var yaml = YamlLoader.Serialize(unit);
+    var result = YamlLoader.Deserialize<UnitDefinition>(yaml);
+
+    return (unit.Id == result.Id)
+        .And(unit.Name == result.Name)
+        .And(unit.Stats.Health == result.Stats.Health)
+        .ToProperty();
+}
+
+// FsCheck property: Registry consistency
+[Property]
+public Property Registry_RegisterAndGet(Unit unit, int priority)
+{
+    var registry = new UnitRegistry();
+    registry.Register(unit.Id, unit, priority, "test");
+
+    var retrieved = registry.Get(unit.Id);
+    return retrieved != null && retrieved.Id == unit.Id;
+}
+
+// FsCheck property: Dependency resolution is acyclic
+[Property]
+public Property DependencyResolver_NoCycles(List<PackManifest> packs)
+{
+    var resolver = new DependencyResolver();
+    var result = resolver.Resolve(packs);
+
+    return result.IsSuccess || result.Error.Contains("circular");
+}
+```
+
+### 14.3 Mutation Testing (Stryker.NET)
+
+```json
+{
+  "stryker-config": {
+    "project-file": "src/SDK/DINOForge.SDK.csproj",
+    "thresholds": {
+      "high": 85,
+      "low": 70,
+      "break": 60
+    },
+    "mutate": [
+      "**/Models/*.cs",
+      "**/Registry/*.cs",
+      "**/Validation/*.cs"
+    ],
+    "reporters": ["progress", "html", "markdown"],
+    "language-version": "Latest"
+  }
+}
+```
+
+---
+
+## 15. Security Models
+
+### 15.1 Mod Security Threats
+
+| Threat | Description | Mitigation | DINOForge Approach |
+|--------|-------------|------------|-------------------|
+| **Malicious Code** | Mods containing malware | Sandboxing, code review | YAML-only content, schema validation |
+| **Data Exfiltration** | Mods stealing user data | Network isolation, permissions | No network access for packs |
+| **Save Corruption** | Mods breaking save files | Save validation, backups | Pack validation before load |
+| **Dependency Confusion** | Typosquatting packages | Verified publishers, checksums | Git submodule verification |
+| **Privilege Escalation** | Mods gaining elevated access | Least privilege, sandboxing | BepInEx plugin isolation |
+
+### 15.2 Content Security Pipeline
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Content Security Pipeline                 │
+│                                                             │
+│  Pack Submission                                            │
+│    │                                                        │
+│    ▼                                                        │
+│  ┌─────────────────┐                                        │
+│  │  Schema         │  Reject invalid content                │
+│  │  Validation     │                                        │
+│  └────────┬────────┘                                        │
+│           │                                                 │
+│           ▼                                                 │
+│  ┌─────────────────┐                                        │
+│  │  Source         │  Verify git submodule origin           │
+│  │  Verification   │  Check commit signatures               │
+│  └────────┬────────┘                                        │
+│           │                                                 │
+│           ▼                                                 │
+│  ┌─────────────────┐                                        │
+│  │  Dependency     │  Verify all dependencies exist         │
+│  │  Validation     │  Check version compatibility           │
+│  └────────┬────────┘                                        │
+│           │                                                 │
+│           ▼                                                 │
+│  ┌─────────────────┐                                        │
+│  │  Conflict       │  Detect content conflicts              │
+│  │  Detection      │  Check priority overlaps               │
+│  └────────┬────────┘                                        │
+│           │                                                 │
+│           ▼                                                 │
+│  ┌─────────────────┐                                        │
+│  │  Asset          │  Verify asset file integrity           │
+│  │  Validation     │  Check file types, sizes               │
+│  └────────┬────────┘                                        │
+│           │                                                 │
+│           ▼                                                 │
+│  Approved Pack → Install                                    │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 16. Distribution & Discovery
+
+### 16.1 Mod Distribution Platforms
+
+| Platform | Type | Games | Features | DINOForge Fit |
+|----------|------|-------|----------|---------------|
+| **Nexus Mods** | Community hub | 2,000+ games | File hosting, mod manager, endorsements | ✅ Planned |
+| **Modrinth** | Open-source | Minecraft, others | API-first, open, modern UX | ✅ Planned |
+| **Thunderstore** | Package manager | Risk of Rain 2, Valheim | CLI, auto-updates | Research |
+| **Steam Workshop** | Platform-integrated | 1000+ games | One-click install, Steam integration | Research |
+| **GitHub Releases** | Developer-focused | Open-source projects | Versioned releases, CI integration | ✅ Current |
+| **Factorio Mods Portal** | Official | Factorio | In-game browser, auto-updates | Reference |
+| **Paradox Mods** | Official | Paradox games | Integrated launcher, monetization | Reference |
+
+### 16.2 Package Metadata Standards
+
+```yaml
+# Proposed DINOForge package metadata (for distribution)
+package:
+  id: warfare-starwars
+  name: "Star Wars: Clone Wars"
+  version: 1.2.0
+  author: DINOForge Team
+  description: "Complete Clone Wars total conversion for DINO"
+  license: MIT
+  homepage: https://github.com/KooshaPari/Dino
+  repository: https://github.com/KooshaPari/Dino
+  issues: https://github.com/KooshaPari/Dino/issues
+
+  # Compatibility
+  framework_version: ">=0.5.0"
+  game_version: ">=1.0.0"
+  platforms: [windows]
+
+  # Dependencies
+  dependencies:
+    dinoforge-core: ">=0.5.0"
+    warfare-domain: ">=0.4.0"
+
+  # Content
+  content:
+    units: 28
+    buildings: 10
+    factions: 2
+    doctrines: 4
+
+  # Assets
+  assets:
+    total_size: "150MB"
+    textures: 56
+    models: 38
+    audio: 0
+
+  # Distribution
+  distribution:
+    nexus_id: null
+    modrinth_id: null
+    github_release: v1.2.0
+    checksum: sha256:abc123...
+```
+
+---
+
+## 17. Community & Governance Models
+
+### 17.1 Mod Community Governance
+
+| Model | Description | Examples | Pros | Cons |
+|-------|-------------|----------|------|------|
+| **Centralized Curation** | Official team reviews mods | Factorio, Paradox | Quality control | Bottleneck |
+| **Community Voting** | Users rate and endorse | Nexus Mods | Democratic | Quality variance |
+| **Open Contribution** | Anyone can publish | GitHub, Modrinth | Low barrier | Quality variance |
+| **Agent-Driven** | AI agents develop and test | DINOForge | Speed, consistency | Novel approach |
+
+### 17.2 Agent-Driven Development (ADR-001)
+
+DINOForge's unique approach to mod development:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Agent-Driven Development                  │
+│                                                             │
+│  Human (Product Owner)                                      │
+│  ├── Define features in natural language                    │
+│  ├── Review test results and diagnostics                    │
+│  ├── Approve releases                                       │
+│  └── Report failures                                        │
+│                                                             │
+│  AI Agents (Development Team)                               │
+│  ├── runtime-specialist: ECS bridge, BepInEx                │
+│  ├── sdk-architect: Registry, SDK, schemas                  │
+│  ├── warfare-designer: Warfare domain, balance              │
+│  ├── pack-builder: Content packs, YAML                      │
+│  ├── toolsmith: CLI tools, PackCompiler                     │
+│  ├── qa-engineer: Tests, CI/CD                              │
+│  └── docs-curator: Documentation, VitePress                 │
+│                                                             │
+│  Coordination (Kilo Gastown)                                │
+│  ├── Rig: 6c6d4555-91e8-4f06-a974-018cf3e766d2             │
+│  ├── Town: 78a8d430-a206-4a25-96c0-5cd9f5caf984            │
+│  ├── Convoy: c61d464c-2332-489e-becb-ebc5d1efa639          │
+│  └── Beads: Tracked work items                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 18. Comparison Matrices
+
+### 18.1 Mod Platform Feature Matrix
+
+| Feature | Factorio | RimWorld | KSP/CKAN | Minecraft | DINOForge |
+|---------|----------|----------|----------|-----------|-----------|
+| **Declarative Content** | ✅ Lua data | ✅ XML | ⚠️ .cfg | ✅ JSON | ✅ YAML |
+| **Code Mods** | ✅ Lua | ✅ C# Harmony | ✅ C# | ✅ Java | ✅ C# (optional) |
+| **Dependency Resolution** | ✅ Built-in | ❌ Manual | ✅ SAT solver | ⚠️ Informal | ✅ Topological |
+| **Schema Validation** | ❌ | ❌ | ✅ JSON | ⚠️ Basic | ✅ 17 schemas |
+| **Hot Reload** | ✅ Data phase | ⚠️ Partial | ❌ | ❌ | ✅ F10 + watcher |
+| **Mod Manager** | ✅ In-game | ❌ | ✅ CKAN GUI | ✅ Modrinth | ✅ WinUI 3 |
+| **Version Control** | ✅ Semver | ❌ | ✅ Semver | ⚠️ Informal | ✅ Semver |
+| **Conflict Detection** | ✅ | ❌ | ✅ | ❌ | ✅ Priority-based |
+| **ECS Integration** | ❌ | ❌ | ❌ | ❌ | ✅ Native |
+| **AI/Agent Tooling** | ❌ | ❌ | ❌ | ❌ | ✅ MCP Server |
+| **Fuzzing/PBT** | ❌ | ❌ | ❌ | ❌ | ✅ FsCheck + SharpFuzz |
+| **Desktop Companion** | ❌ | ❌ | ❌ | ❌ | ✅ WinUI 3 |
+| **Multi-Instance** | ❌ | ❌ | ❌ | ❌ | ✅ Planned |
+
+### 18.2 Technology Adoption Matrix
+
+| Technology | Industry Adoption | DINOForge Adoption | Maturity |
+|------------|------------------|-------------------|----------|
+| **YAML Content** | Growing (RimWorld XML → YAML trend) | ✅ Primary | Mature |
+| **JSON Schema** | Standard | ✅ 17 schemas | Mature |
+| **ECS-Native Modding** | None (DINOForge first) | ✅ Primary | Emerging |
+| **BepInEx** | Standard for Unity | ✅ Primary | Mature |
+| **MCP Server** | Emerging (2024+) | ✅ 16+ tools | Emerging |
+| **Property-Based Testing** | Growing | ✅ FsCheck | Mature |
+| **Mutation Testing** | Niche | ✅ Stryker.NET | Mature |
+| **WinUI 3 Companion** | Rare | ✅ Active | Mature |
+| **Neural Asset Pipeline** | Emerging | ✅ Proposed (ADR-021) | Emerging |
+| **Agent-Driven Dev** | Novel | ✅ Primary | Novel |
+
+### 18.3 Performance Comparison
+
+| Metric | Harmony-Based | ECS-Native (DINOForge) | Improvement |
+|--------|--------------|----------------------|-------------|
+| **Frame overhead** | 2-5ms | 0.3-1ms | 5-10x |
+| **Entity query** | O(n) reflection | O(1) archetype | 100x+ |
+| **Memory per entity** | 64-128 bytes | 16-32 bytes | 4x |
+| **Burst compilation** | ❌ | ✅ | 2-4x |
+| **Hot reload latency** | N/A | ~300ms | N/A |
+| **Pack load time** | N/A | ~50ms/pack | N/A |
+
+---
+
+## 19. Code Examples & Reference Implementations
+
+### 19.1 Pack Manifest (Complete Example)
+
+```yaml
+# packs/warfare-starwars/pack.yaml
+id: warfare-starwars
+name: "Star Wars: Clone Wars"
+version: 1.2.0
+author: DINOForge Team
+type: total-conversion
+framework_version: ">=0.5.0"
+priority: 3000
+
+description: |
+  Complete Clone Wars total conversion featuring
+  Galactic Republic vs CIS factions with 28 units
+  and 10 buildings.
+
+homepage: https://github.com/KooshaPari/Dino
+license: MIT
+
+loads:
+  units:
+    - units/republic/
+    - units/cis/
+  buildings:
+    - buildings/republic/
+    - buildings/cis/
+  factions:
+    - factions/
+  doctrines:
+    - doctrines/
+  waves:
+    - waves/
+
+depends:
+  - id: dinoforge-core
+    version: ">=0.5.0"
+  - id: warfare-domain
+    version: ">=0.4.0"
+
+conflicts:
+  - id: warfare-modern
+    reason: "Different theme setting"
+  - id: warfare-guerrilla
+    reason: "Different theme setting"
+
+assets:
+  bundle_name: "warfare_starwars_bundle"
+  addressables_group: "warfare-starwars"
+  catalog_entries: 38
+  lod_levels: 3  # 100%, 60%, 30%
+```
+
+### 19.2 Unit Definition (Complete Example)
+
+```yaml
+# units/republic/clone_trooper.unit.yaml
+id: starwars:clone_trooper
+name: "Clone Trooper"
+description: "Standard Republic infantry unit. Trained from birth, \
+  equipped with DC-15A blaster rifle."
+
+archetype: infantry
+role: frontline
+faction: starwars:galactic_republic
+
+visual:
+  prefab_address: "warfare-starwars/CloneTrooperPrefab"
+  icon_address: "warfare-starwars/Icons/CloneTrooper"
+  scale: 1.0
+  lod_levels:
+    - distance: 0
+      quality: 100
+    - distance: 50
+      quality: 60
+    - distance: 100
+      quality: 30
+
+stats:
+  health: 150
+  armor: 10
+  speed: 3.5
+  morale: 80
+  accuracy: 75
+
+combat:
+  weapon: starwars:dc15a_blaster
+  range: 15.0
+  damage: 25
+  fire_rate: 0.5
+  attack_type: ranged
+
+cost:
+  wood: 50
+  stone: 0
+  iron: 25
+  gold: 0
+  population: 1
+  build_time: 8.0
+
+abilities:
+  - id: formation_line
+    name: "Line Formation"
+    description: "+10% accuracy when in line formation"
+    effect:
+      accuracy: +10
+      condition: formation == line
+
+  - id: clone_training
+    name: "Clone Training"
+    description: "+15% morale when near other clones"
+    effect:
+      morale: +15
+      condition: nearby_units.faction == self.faction
+
+variants:
+  - id: veteran
+    name: "Veteran Clone Trooper"
+    description: "Experienced clone trooper with enhanced stats"
+    stat_modifiers:
+      health: +50
+      armor: +5
+      accuracy: +10
+      morale: +10
+
+  - id: captain
+    name: "Clone Captain"
+    description: "Elite clone trooper officer"
+    stat_modifiers:
+      health: +100
+      armor: +15
+      accuracy: +15
+      morale: +20
+    abilities:
+      - id: rallying_cry
+        name: "Rallying Cry"
+        description: "+20% morale to nearby units"
+        effect:
+          morale: +20
+          condition: nearby_units.faction == self.faction
+          radius: 10.0
+```
+
+### 19.3 Registry Implementation
+
+```csharp
+// SDK/Registry/TypedRegistry.cs
+public class TypedRegistry<T> : IRegistry<T> where T : class, IRegisteredContent
+{
+    private readonly Dictionary<string, List<RegistryEntry<T>>> _entries
+        = new();
+
+    private readonly Dictionary<string, string> _sources = new();
+    private readonly object _lock = new();
+
+    public void Register(string id, T content, int priority, string sourcePack)
+    {
+        lock (_lock)
+        {
+            if (!_entries.ContainsKey(id))
+            {
+                _entries[id] = new List<RegistryEntry<T>>();
+            }
+
+            var entry = new RegistryEntry<T>(content, priority, sourcePack);
+            _entries[id].Add(entry);
+            _entries[id].Sort((a, b) => b.Priority.CompareTo(a.Priority));
+
+            // Detect conflicts
+            var topPriority = _entries[id][0].Priority;
+            var conflicts = _entries[id]
+                .Where(e => e.Priority == topPriority)
+                .Select(e => e.SourcePack)
+                .Distinct()
+                .ToList();
+
+            if (conflicts.Count > 1)
+            {
+                throw new RegistryConflictException(
+                    $"Content '{id}' registered by multiple packs " +
+                    $"at same priority: {string.Join(", ", conflicts)}");
+            }
+
+            _sources[id] = sourcePack;
+        }
+    }
+
+    public T? Get(string id)
+    {
+        lock (_lock)
+        {
+            if (_entries.TryGetValue(id, out var entries) && entries.Count > 0)
+            {
+                return entries[0].Content;
+            }
+            return null;
+        }
+    }
+
+    public IReadOnlyDictionary<string, T> GetAll()
+    {
+        lock (_lock)
+        {
+            return _entries
+                .Where(kvp => kvp.Value.Count > 0)
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value[0].Content);
+        }
+    }
+
+    public IReadOnlyList<string> GetConflicts()
+    {
+        lock (_lock)
+        {
+            return _entries
+                .Where(kvp => kvp.Value.Count > 1
+                    && kvp.Value[0].Priority == kvp.Value[1].Priority)
+                .Select(kvp => kvp.Key)
+                .ToList();
+        }
+    }
+}
+
+public record RegistryEntry<T>(T Content, int Priority, string SourcePack);
+```
+
+### 19.4 Dependency Resolver
+
+```csharp
+// SDK/Dependencies/DependencyResolver.cs
+public class DependencyResolver
+{
+    public DependencyResolutionResult Resolve(
+        IReadOnlyList<PackManifest> manifests)
+    {
+        // Build dependency graph
+        var graph = new DirectedGraph<string>();
+        var manifestMap = manifests.ToDictionary(m => m.Id);
+
+        foreach (var manifest in manifests)
+        {
+            graph.AddNode(manifest.Id);
+
+            foreach (var dep in manifest.Depends)
+            {
+                if (!manifestMap.ContainsKey(dep.Id))
+                {
+                    return DependencyResolutionResult.MissingDependency(
+                        manifest.Id, dep.Id);
+                }
+
+                graph.AddEdge(manifest.Id, dep.Id);
+            }
+        }
+
+        // Detect circular dependencies
+        var cycle = graph.FindCycle();
+        if (cycle != null)
+        {
+            return DependencyResolutionResult.CircularDependency(cycle);
+        }
+
+        // Topological sort
+        var loadOrder = graph.TopologicalSort();
+
+        // Validate version constraints
+        foreach (var packId in loadOrder)
+        {
+            var manifest = manifestMap[packId];
+            foreach (var dep in manifest.Depends)
+            {
+                var depManifest = manifestMap[dep.Id];
+                if (!VersionSatisfies(depManifest.Version, dep.Version))
+                {
+                    return DependencyResolutionResult.VersionConflict(
+                        packId, dep.Id, depManifest.Version, dep.Version);
+                }
+            }
+        }
+
+        return DependencyResolutionResult.Success(loadOrder);
+    }
+
+    private bool VersionSatisfies(string actual, string constraint)
+    {
+        // Parse semver constraint: ">=0.5.0", "^1.0.0", "~1.2.0"
+        var actualVersion = SemVer.Parse(actual);
+        var constraintRange = SemVer.ParseRange(constraint);
+
+        return constraintRange.Satisfies(actualVersion);
+    }
+}
+```
+
+### 19.5 MCP Tool Implementation
+
+```csharp
+// Tools/McpServer/Tools/GameStatusTool.cs
+[McpServerTool("game_status")]
+public class GameStatusTool : IMcpTool
+{
+    public string Name => "game_status";
+    public string Description => "Check if game is running and mods loaded";
+
+    public async Task<ToolResult> ExecuteAsync(ToolContext context)
+    {
+        var bridge = context.Get<IGameBridge>();
+
+        if (!bridge.IsConnected)
+        {
+            return ToolResult.Error("Game is not running or bridge not connected");
+        }
+
+        var status = await bridge.GetStatusAsync();
+
+        return ToolResult.Success(new
+        {
+            running = true,
+            entity_count = status.EntityCount,
+            loaded_packs = status.LoadedPacks,
+            ecs_world_ready = status.WorldReady,
+            frame_count = status.FrameCount,
+            uptime = status.Uptime
+        });
+    }
+}
+```
+
+### 19.6 Schema Validation Pipeline
+
+```csharp
+// SDK/Validation/SchemaValidator.cs
+public class SchemaValidator : ISchemaValidator
+{
+    private readonly Dictionary<string, JsonSchema> _schemas = new();
+
+    public async Task<ValidationResult> ValidateAsync(
+        string contentPath,
+        string schemaName)
+    {
+        var schema = await GetSchemaAsync(schemaName);
+        var content = await File.ReadAllTextAsync(contentPath);
+
+        // Parse YAML to JSON for schema validation
+        var yamlObject = YamlLoader.Parse(content);
+        var json = JsonConvert.SerializeObject(yamlObject);
+
+        var validationResult = schema.Validate(json);
+
+        if (validationResult.IsValid)
+        {
+            return ValidationResult.Success(contentPath);
+        }
+
+        var errors = validationResult.Errors
+            .Select(e => new ValidationError
+            {
+                Path = e.Path,
+                Message = e.Kind.ToString(),
+                LineNumber = e.LineNumber,
+                LinePosition = e.LinePosition
+            })
+            .ToList();
+
+        return ValidationResult.Failure(contentPath, errors);
+    }
+
+    private async Task<JsonSchema> GetSchemaAsync(string schemaName)
+    {
+        if (!_schemas.ContainsKey(schemaName))
+        {
+            var schemaPath = Path.Combine("schemas", $"{schemaName}.schema.json");
+            var schemaJson = await File.ReadAllTextAsync(schemaPath);
+            _schemas[schemaName] = JsonSchema.FromJsonAsync(schemaJson).Result;
+        }
+
+        return _schemas[schemaName];
+    }
+}
+```
+
+---
+
+## 20. Emerging Trends (2025-2026)
+
+### 20.1 AI-Assisted Mod Development
+
+| Trend | Status | Impact | DINOForge Relevance |
+|-------|--------|--------|-------------------|
+| **Neural Asset Generation** | Emerging | High | ✅ ADR-021 |
+| **AI Code Generation** | Growing | High | ✅ Agent-driven dev |
+| **Automated Testing** | Growing | Medium | ✅ MCP test tools |
+| **Natural Language Modding** | Research | High | Future |
+| **AI Balance Tuning** | Research | Medium | Future |
+
+### 20.2 Cross-Platform Modding
+
+| Trend | Status | Impact | DINOForge Relevance |
+|-------|--------|--------|-------------------|
+| **Multi-Engine Support** | Research | Medium | Future |
+| **Web-Based Mod Builders** | Emerging | High | Planned |
+| **Cloud Asset Processing** | Growing | Medium | Research |
+| **Cross-Game Mod Sharing** | Research | Low | Future |
+
+### 20.3 Developer Experience
+
+| Trend | Status | Impact | DINOForge Relevance |
+|-------|--------|--------|-------------------|
+| **IDE Integration** | Growing | High | VS Code JSON Schema |
+| **Live Preview** | Emerging | High | Desktop Companion |
+| **Collaborative Modding** | Growing | Medium | Git submodules |
+| **CI/CD for Mods** | Growing | High | GitHub Actions |
+
+---
+
+## 21. DINOForge Positioning
+
+### 21.1 Unique Value Propositions
+
+1. **First ECS-Native Mod Platform**: No other mod platform targets Unity ECS/DOTS as a first-class citizen
+2. **Agent-Driven Development**: Unique methodology where AI agents handle all coding
+3. **YAML-First Declarative Modding**: Lower barrier than code-first approaches
+4. **Comprehensive Validation**: 17 schemas catch errors before runtime
+5. **MCP Integration**: AI-assisted mod development and testing
+6. **Desktop Companion**: Standalone management tool (WinUI 3)
+7. **Fuzzing Infrastructure**: FsCheck + SharpFuzz for robustness
+
+### 21.2 Competitive Advantages
+
+| Advantage | DINOForge | Nearest Competitor | Gap |
+|-----------|-----------|-------------------|-----|
+| ECS Integration | ✅ Native | None | Pioneering |
+| Agent Development | ✅ Primary | None | Pioneering |
+| Schema Validation | ✅ 17 schemas | SMAPI (basic) | Significant |
+| Fuzzing/PBT | ✅ FsCheck + SharpFuzz | None | Pioneering |
+| Desktop Companion | ✅ WinUI 3 | Thunderstore Manager | Comparable |
+| Hot Reload | ✅ F10 + watcher | Factorio data phase | Comparable |
+| Dependency Resolution | ✅ Topological | CKAN SAT solver | Moderate |
+| Distribution | ⚠️ GitHub only | Modrinth/Nexus | Significant gap |
+
+### 21.3 Maturity Assessment
+
+| Area | Maturity | Notes |
+|------|----------|-------|
+| **Runtime Layer** | Production | 1017+ tests, stable |
+| **SDK Layer** | Production | Published to NuGet |
+| **Pack System** | Production | 6 example packs |
+| **Schema Validation** | Production | 17 schemas |
+| **ECS Bridge** | Production | 30+ component mappings |
+| **Hot Reload** | Production | F10 + file watcher |
+| **MCP Server** | Production | 16+ tools |
+| **Desktop Companion** | Production | WinUI 3, Mica |
+| **Fuzzing** | Production | FsCheck + SharpFuzz |
+| **Distribution** | Developing | GitHub Releases only |
+| **Asset Pipeline** | Developing | Neural pipeline proposed |
+| **Multi-Instance** | Proposed | ADR-020, ADR-022 |
+
+---
+
+## 22. Recommendations
+
+### 22.1 Immediate Priorities
+
+1. **Distribution Platform Integration**: Implement Nexus Mods and/or Modrinth publishing pipeline
+2. **Web-Based Pack Validator**: Build smapi.io-style web validator for pack authors
+3. **VS Code Extension**: JSON Schema integration for YAML editing with autocomplete
+4. **CKAN-Style Dependency Resolution**: Upgrade from topological sort to SAT-based resolver
+
+### 22.2 Medium-Term Goals
+
+1. **Neural Asset Pipeline**: Implement ADR-021 phases (concept art → textures → 3D)
+2. **Multi-Instance MCP**: Implement ADR-022 orchestration model
+3. **Web-Based Mod Builder**: Browser-based pack creation for non-technical users
+4. **Community Tools**: Diff viewer, conflict detector, balance calculator
+
+### 22.3 Long-Term Vision
+
+1. **Mod Marketplace**: Official DINOForge mod portal with in-game browser
+2. **Cross-Game SDK**: Generalize SDK for other Unity ECS games
+3. **AI Balance Tuning**: Automated balance analysis and recommendations
+4. **Natural Language Modding**: Text-to-pack generation via AI
+
+### 22.4 Technology Decisions
+
+| Decision | Recommendation | Rationale |
+|----------|---------------|-----------|
+| **Content Format** | Keep YAML | Superior to XML/JSON for readability |
+| **Schema Version** | Draft 2020-12 | Latest standard, future-proof |
+| **Dependency Resolver** | SAT-based (CKAN-style) | More robust than topological sort |
+| **Asset Format** | FBX primary, glTF research | Industry standard, Unity support |
+| **Mod Loader** | BepInEx 5.4.x | Mature, ECS-compatible |
+| **Desktop Framework** | WinUI 3 | Modern, Mica support |
+| **Testing** | xUnit + FsCheck + Stryker | Comprehensive coverage |
+| **Distribution** | Nexus Mods + GitHub | Largest mod community |
+
+---
+
+## 23. References
+
+### Primary Sources
+
+- [Factorio Modding Wiki](https://wiki.factorio.com/Modding)
+- [Factorio Lua API](https://lua-api.factorio.com/latest/)
+- [RimWorld Modding Wiki](https://rimworldmodding.wiki.gg/)
+- [CKAN GitHub](https://github.com/KSP-CKAN/CKAN)
+- [SMAPI Documentation](https://smapi.io/)
+- [Content Patcher](https://stardewvalleywiki.com/Modding:Content_Patcher)
+- [Minecraft Fabric Wiki](https://wiki.fabricmc.net/)
+- [Modrinth](https://modrinth.com/)
+- [Nexus Mods](https://www.nexusmods.com/)
+- [BepInEx Documentation](https://docs.bepinex.dev/)
+- [Unity ECS Documentation](https://docs.unity3d.com/Packages/com.unity.entities@1.0/manual/index.html)
+- [JSON Schema Specification](https://json-schema.org/)
+- [Model Context Protocol](https://modelcontextprotocol.io/)
+
+### DINOForge Internal References
+
+- [ADR-001: Agent-Driven Development](../adr/ADR-001-agent-driven-development.md)
+- [ADR-002: Declarative-First Architecture](../adr/ADR-002-declarative-first-architecture.md)
+- [ADR-003: Pack System Design](../adr/ADR-003-pack-system-design.md)
+- [ADR-004: Registry Model](../adr/ADR-004-registry-model.md)
+- [ADR-005: ECS Integration Strategy](../adr/ADR-005-ecs-integration-strategy.md)
+- [ADR-006: Domain Plugin Architecture](../adr/ADR-006-domain-plugin-architecture.md)
+- [ADR-007: Observability First](../adr/ADR-007-observability-first.md)
+- [ADR-008: Wrap, Don't Handroll](../adr/ADR-008-wrap-dont-handroll.md)
+- [ADR-009: Runtime Orchestration](../adr/ADR-009-runtime-orchestration.md)
+- [ADR-010: Asset Intake Pipeline](../adr/ADR-010-asset-intake-pipeline.md)
+- [ADR-011: Desktop Companion](../adr/ADR-011-desktop-companion.md)
+- [ADR-012: Fuzzing Strategy](../adr/ADR-012-fuzzing-strategy.md)
+- [ADR-019: Mod Manager Client](../adr/ADR-019-mod-manager-client.md)
+- [ADR-020: Multi-Instance Concurrency](../adr/ADR-020-multi-instance-concurrency.md)
+- [ADR-021: Neural Asset Pipeline](../adr/ADR-021-neural-asset-pipeline.md)
+- [ADR-022: MCP Orchestration](../adr/ADR-022-mcp-orchestration.md)
+- [Product Requirements Document](../product-requirements-document.md)
+- [Modding Research](../reference/modding-research.md)
+- [Architecture Concepts](../concepts/architecture.md)
+
+### Industry Analysis
+
+- [Mod DB Statistics](https://www.moddb.com/)
+- [Nexus Mods Statistics](https://www.nexusmods.com/stats)
+- [Steam Workshop Analytics](https://steamcommunity.com/workshop/browse/)
+- [Game Modding Market Report 2025](https://www.newzoo.com/)
+- [Unity ECS Performance Guide](https://docs.unity3d.com/Packages/com.unity.entities@1.0/manual/performance.html)
+
+---
+
+*This document is part of the DINOForge documentation suite. For questions or contributions, refer to the [CONTRIBUTING.md](../../CONTRIBUTING.md) guide.*

--- a/docs/research/game-modding-sota.md
+++ b/docs/research/game-modding-sota.md
@@ -1,0 +1,1553 @@
+# SOTA Research: Game Modding Landscape (2024-2026)
+
+> Comprehensive survey of state-of-the-art technologies for Unity game modding, automation testing, and content pipelines
+
+**Document Version**: 1.0  
+**Last Updated**: 2026-04-04  
+**Author**: DINOForge Research Team
+
+---
+
+## Table of Contents
+
+1. [Unity Runtime Internals](#1-unity-runtime-internals)
+2. [Mod Loader Technologies](#2-mod-loader-technologies)
+3. [ECS/DOTS Evolution](#3-ecsdots-evolution)
+4. [Asset Pipeline Technologies](#4-asset-pipeline-technologies)
+5. [Content Modding Patterns](#5-content-modding-patterns)
+6. [Hot Reload Technologies](#6-hot-reload-technologies)
+7. [Game Automation Frameworks](#7-game-automation-frameworks)
+8. [Computer Vision for Games](#8-computer-vision-for-games)
+9. [Property Testing & Fuzzing](#9-property-testing--fuzzing)
+10. [Multi-Instance Orchestration](#10-multi-instance-orchestration)
+11. [Neural Asset Generation](#11-neural-asset-generation)
+12. [MCP & Agent Protocols](#12-mcp--agent-protocols)
+13. [Cross-Platform Considerations](#13-cross-platform-considerations)
+14. [Security & Anti-Cheat](#14-security--anti-cheat)
+15. [Community & Distribution](#15-community--distribution)
+
+---
+
+## 1. Unity Runtime Internals
+
+### 1.1 Unity Version Evolution
+
+| Version | Release | ECS | Rendering | Modding Impact |
+|---------|---------|-----|-----------|----------------|
+| **2021 LTS** | 2021.3.x | Entities 0.50 (preview) | Built-in/BiRP | Legacy modding |
+| **2022 LTS** | 2022.3.x | Entities 1.0 | URP 14.x | DINOForge target |
+| **2023 LTS** | 2023.2.x | Entities 1.1 | URP 16.x | Future target |
+| **Unity 6** | 6000.0.x | Entities 2.0 | URP 18.x | Research |
+
+### 1.2 Runtime Scripting Backends
+
+| Backend | Compilation | Modding Access | Performance | DINOForge Support |
+|---------|-------------|----------------|-------------|-------------------|
+| **Mono** | JIT | Full reflection | Good | Primary |
+| **IL2CPP** | AOT + C++ | Limited (metadata) | Excellent | Metadata required |
+| **CoreCLR** | JIT (future) | Full reflection | Excellent | Future |
+
+### 1.3 Unity Player Architecture
+
+```
+Unity Player Architecture
+=========================
+
+Scripting Layer
+  - C# Scripts (Assembly-CSharp)
+  - Mod DLLs (plugins/)
+  - BepInEx (patchers)
+
+Unity Runtime (libil2cpp/Mono)
+  - GC (Boehm/SS)
+  - Type System (Metadata)
+  - Reflection (Runtime)
+
+Engine Core
+  - ECS World (Entities)
+  - Scene Management
+  - Asset System
+```
+
+### 1.4 Unity ECS Memory Layout
+
+| Feature | Description | Modding Implication |
+|---------|-------------|---------------------|
+| **Archetypes** | Entities with same component types grouped | Query by component signature |
+| **Chunks** | 16KB blocks of homogeneous entities | Direct memory access possible |
+| **Component Arrays** | Structure of Arrays (SoA) layout | Efficient bulk operations |
+| **EntityManager** | Central entity lifecycle | Hook for spawn/despawn |
+| **SystemBase** | Logic execution units | Injection point for mod systems |
+
+### 1.5 Unity Player Loop
+
+```
+Initialization
+    |
+    v
+Early Update (Input, XR, Mod hooks: PreInput)
+    |
+    v
+Fixed Update (Physics, Mod hooks: Pre/Post Physics)
+    |
+    v
+Update (Main game systems, Primary mod logic)
+    |
+    v
+PreLate Update (Late mod logic)
+    |
+    v
+PostLate Update (Rendering prep, Rendering mods)
+    |
+    v
+Render/Draw (Post-render hooks)
+```
+
+---
+
+## 2. Mod Loader Technologies
+
+### 2.1 BepInEx Deep Dive
+
+BepInEx is the de facto standard for Unity modding.
+
+#### BepInEx Architecture
+
+```
+BepInEx Architecture
+====================
+
+Entry Points:
+  - Doorstop (native DLL) - Injects at Unity init
+  - Preloader - Loads patcher assemblies
+  - Chainloader - Loads plugin assemblies
+
+Core Components:
+  BepInEx.Preloader
+    - MonoPreloader (for Mono runtime)
+    - IL2CPPPreloader (for IL2CPP runtime)
+  
+  BepInEx.Core
+    - BaseUnityPlugin (mod base class)
+    - ConfigFile (settings persistence)
+    - ManualLogSource (logging)
+    - Chainloader (plugin orchestration)
+  
+  BepInEx.Unity
+    - UnityPlugin (MonoBehaviour wrapper)
+    - UnityLogListener (Unity Debug to BepInEx log)
+
+Harmony Integration:
+  - MonoMod.RuntimeDetour.HookGen (method hooking)
+  - HarmonyX (method patching)
+  - IL Manipulation (runtime code modification)
+```
+
+#### BepInEx Plugin Lifecycle
+
+| Phase | Method | Purpose | DINOForge Usage |
+|-------|--------|---------|-----------------|
+| **Load** | Constructor | Initialize config, logging | Setup ModPlatform |
+| **Awake** | void Awake() | Early initialization | Discover packs |
+| **Start** | void Start() | Main initialization | Load content |
+| **Update** | void Update() | Per-frame logic | Hot reload check |
+| **OnDestroy** | void OnDestroy() | Cleanup | Save state |
+
+### 2.2 Alternative Mod Loaders
+
+| Loader | Unity Support | Runtime | Pros | Cons |
+|--------|---------------|---------|------|------|
+| **MelonLoader** | Mono + IL2CPP | Mono/IL2CPP | Cross-platform, modern | Steeper learning curve |
+| **UnityInjector** | Mono only | Mono | Simple | Deprecated, limited |
+| **UMM** | 2017+ | Both | User-friendly | Less powerful |
+| **BSIPA** | 2018+ | Both | Beat Saber optimized | Game-specific |
+
+### 2.3 Hooking Techniques
+
+| Technique | Level | Performance | Detection Risk | DINOForge Use |
+|-----------|-------|-------------|----------------|---------------|
+| **Harmony Patches** | Managed | Low | Low | Event hooks |
+| **MonoDetour** | Managed | Low | Low | Advanced patches |
+| **Native Hooks** | Native | High | Medium | Low-level access |
+| **IL Editing** | Pre-runtime | N/A | None | Patcher assemblies |
+
+### 2.4 IL2CPP Modding Challenges
+
+IL2CPP (Intermediate Language to C++) compilation creates unique modding challenges:
+
+| Challenge | Impact | Solution |
+|-----------|--------|----------|
+| **No JIT** | Cannot emit IL at runtime | AOT-compatible patterns |
+| **Stripped Metadata** | Missing type info | Use unstripped metadata |
+| **C++ Symbols** | Hard to hook | Pattern scanning |
+| **Reverse Complexity** | Harder to analyze | Dumps + heuristics |
+
+DINOForge Approach: Focus on ECS component access which is more stable than method hooking.
+
+---
+
+## 3. ECS/DOTS Evolution
+
+### 3.1 ECS Implementation Comparison
+
+| System | Language | Storage | Query Perf | Modding Access |
+|--------|----------|---------|------------|----------------|
+| **Unity ECS** | C# | Archetype chunks | 1M+ entities/ms | Component access |
+| **Entitas** | C# | AoS + indices | 500K entities/ms | Full source |
+| **Svelto.ECS** | C# | Cache-aware | 800K entities/ms | Extension points |
+| **LeoECS** | C# | Sparse sets | 600K entities/ms | Simple API |
+| **DefaultEcs** | C# | Sparse sets | 600K entities/ms | Modern C# |
+| **flecs** | C | Archetype | 2M+ entities/ms | C API |
+| **Bevy ECS** | Rust | Archetype | 1.5M entities/ms | Component queries |
+
+### 3.2 Unity ECS Component Types
+
+| Component Type | Storage | Use Case | Modding Pattern |
+|---------------|---------|----------|-----------------|
+| **IComponentData** | Chunk | Data | Read/write override |
+| **IBufferElementData** | Chunk buffer | Dynamic arrays | Append/modify |
+| **ISharedComponentData** | Archetype | Shared data | Query filtering |
+| **Entity** | Implicit | References | Spawn/despawn |
+| **BlobAssetReference** | Blob | Immutable data | Content injection |
+
+### 3.3 ECS Query Patterns
+
+```csharp
+// DINOForge query patterns for modding
+
+// Query all units with health
+var query = EntityManager.CreateEntityQuery(
+    ComponentType.ReadOnly<Health>(),
+    ComponentType.ReadOnly<UnitId>()
+);
+
+// System-based query with parallel execution
+public class ModStatSyncSystem : SystemBase
+{
+    protected override void OnUpdate()
+    {
+        Entities
+            .WithAll<UnitId, Health>()
+            .ForEach((ref Health health, in UnitId id) =>
+            {
+                var def = Registry.GetUnit(id.Value);
+                health.MaxValue = def.Stats.Health;
+            }).ScheduleParallel();
+    }
+}
+```
+
+### 3.4 ECS Modding Strategies
+
+| Strategy | Implementation | Pros | Cons |
+|----------|----------------|------|------|
+| **Component Override** | Write to vanilla components | Direct effect | May conflict |
+| **Shadow Components** | Parallel mod components | Clean separation | Sync overhead |
+| **System Injection** | Add mod systems to world | Powerful | Complex ordering |
+| **Entity Queries** | Read vanilla, mod behavior | Safe | Read-only |
+
+### 3.5 DINOForge ECS Bridge Pattern
+
+```
+ECS Bridge Architecture
+=======================
+
+Vanilla ECS World
+  - Entities with vanilla components
+  - Systems processing vanilla logic
+
+DINOForge Bridge Layer
+  - ModUnitDefinitionComponent (stores mod content ID)
+  - StatOverrideComponent (runtime overrides)
+  - AssetSwapComponent (visual replacements)
+
+Sync Systems
+  - StatSyncSystem: Mod stats to Vanilla health/damage
+  - VisualSyncSystem: Mod assets to Mesh/material
+  - CleanupSystem: Handle entity destruction
+
+Read-Only Queries
+  - Entity position, rotation (for spawn positioning)
+  - Vanilla component values (for balance analysis)
+```
+
+---
+
+## 4. Asset Pipeline Technologies
+
+### 4.1 Unity Addressables System
+
+Addressables is Unity's modern asset management system.
+
+```
+Addressables System
+===================
+
+Build Phase
+  - Asset Groups (logical collections)
+  - Bundle Packing (AssetBundle creation)
+  - Catalog Generation (JSON manifest)
+
+Runtime Phase
+  - Catalog Loading (from local/remote)
+  - Asset Resolution (key to bundle to asset)
+  - Dependency Loading (automatic)
+
+Caching
+  - Local Cache (downloaded bundles)
+  - Hash-based Invalidation
+  - LRU Eviction
+```
+
+### 4.2 Addressables Performance
+
+| Operation | Latency | Memory | Notes |
+|-----------|---------|--------|-------|
+| Catalog Load | 10-100ms | ~1MB | One-time |
+| Asset Load | 1-50ms | Asset size | From local cache |
+| Remote Download | 100ms-10s | Asset size | Network dependent |
+| Bundle Unload | Instant | Freed | Reference counting |
+
+### 4.3 Asset Bundle Formats
+
+| Format | Compression | Platform | Use Case |
+|--------|-------------|----------|----------|
+| **LZ4** | Fast | All | Runtime loading |
+| **LZMA** | High | All | Size-critical |
+| **Uncompressed** | None | All | Fastest loading |
+| **AssetBundle (LZ4HC)** | Better LZ4 | All | Recommended |
+
+### 4.4 3D Asset Formats
+
+| Format | Animation | PBR | Size | Unity Import | Mod Use |
+|--------|-----------|-----|------|--------------|---------|
+| **FBX** | Yes | Yes | Large | Native | Primary |
+| **glTF 2.0** | Yes | Yes | Medium | Plugin | Future |
+| **USD/USDZ** | Yes | Yes | Large | Plugin | Research |
+| **OBJ** | No | No | Medium | Native | Legacy |
+
+### 4.5 Texture Compression
+
+| Format | Alpha | HDR | Size | GPU Support | Quality |
+|--------|-------|-----|------|-------------|---------|
+| **DXT1 (BC1)** | 1-bit | No | 1:8 | Universal | Low |
+| **DXT5 (BC3)** | Yes | No | 1:4 | Universal | Medium |
+| **BC7** | Yes | No | 1:4 | DX11+ | High |
+| **ASTC** | Yes | Variable | Variable | Mobile | Variable |
+
+### 4.6 DINOForge Asset Pipeline
+
+| Stage | Tool | Output | Validation |
+|-------|------|--------|------------|
+| **Import** | Unity Editor | .meta, .asset | File existence |
+| **Validate** | PackCompiler | Report | Schema + references |
+| **Optimize** | Unity | LODs, compressed | Size limits |
+| **Build** | Addressables | .bundle, catalog.json | Load test |
+| **Package** | PackCompiler | .zip | Integrity hash |
+
+---
+
+## 5. Content Modding Patterns
+
+### 5.1 Declarative vs Imperative Modding
+
+| Pattern | Format | Pros | Cons | Use Case |
+|---------|--------|------|------|----------|
+| **Declarative** | YAML/JSON | Readable, diffable, safe | Less flexible | Stats, costs |
+| **Imperative** | C#/Lua | Powerful, dynamic | Complex, error-prone | Behavior scripts |
+| **Hybrid** | YAML + C# | Best of both | More complex | Full conversions |
+
+### 5.2 Data-Driven Design Patterns
+
+**Pattern 1: ScriptableObject Registry (Traditional Unity)**
+```csharp
+[CreateAssetMenu]
+public class UnitDefinition : ScriptableObject
+{
+    public string unitName;
+    public int health;
+    public GameObject prefab;
+}
+```
+
+**Pattern 2: ECS Pure Data (DINOForge approach)**
+```csharp
+public struct UnitDefinition
+{
+    public string Id;
+    public string Name;
+    public StatBlock Stats;
+    public CostBlock Cost;
+    public string PrefabAddress; // Addressables key
+}
+```
+
+**Pattern 3: YAML + Runtime Binding**
+```yaml
+id: starwars:clone_trooper
+name: "Clone Trooper"
+stats:
+  health: 150
+  armor: 10
+prefab_address: "warfare-starwars/CloneTrooper"
+```
+
+### 5.3 Override Priority Systems
+
+| System | Merge Strategy | Conflict Resolution | DINOForge Use |
+|--------|----------------|---------------------|---------------|
+| **Priority Stack** | Higher wins | Explicit ordering | Registry |
+| **Dependency Graph** | Topological | Dependency order | Pack loading |
+| **Conflict Detection** | Error on overlap | Manual resolution | Validation |
+
+### 5.4 Content Validation Strategies
+
+| Level | Method | Coverage | Speed |
+|-------|--------|----------|-------|
+| **Schema** | JSON Schema | Structure, types | ~5ms |
+| **Reference** | ID cross-check | Links valid | ~10ms |
+| **Semantic** | Business rules | Game logic | ~50ms |
+| **Runtime** | Load test | Actual loading | ~100ms |
+
+### 5.5 Pack Manifest Standards
+
+```yaml
+id: warfare-starwars
+name: "Star Wars: Clone Wars"
+version: 1.0.0
+type: total-conversion
+framework_version: ">=0.1.0"
+
+loads:
+  units:
+    - units/
+  buildings:
+    - buildings/
+  factions:
+    - factions/
+
+depends:
+  - id: dinoforge-core
+    version: ">=0.1.0"
+
+conflicts:
+  - id: warfare-fantasy
+    reason: "Different theme setting"
+
+priority: 3000
+```
+
+---
+
+## 6. Hot Reload Technologies
+
+### 6.1 Code Hot Reload
+
+| Approach | Granularity | State Preservation | Complexity | DINOForge Status |
+|----------|-------------|-------------------|------------|------------------|
+| **Assembly.Load** | Assembly | Lost | Low | Primary |
+| **AssemblyLoadContext** | Assembly | Selective | Medium | Research |
+| **Roslyn Compilation** | Method | Context-dependent | High | Not planned |
+
+### 6.2 Content Hot Reload
+
+| Approach | Latency | State Impact | DINOForge Status |
+|----------|---------|------------|------------------|
+| **FileSystemWatcher** | ~100ms | Minimal | Primary |
+| **Manual F10** | Instant | Controlled | Primary |
+| **WebSocket trigger** | ~50ms | Minimal | MCP integration |
+
+### 6.3 Hot Reload Architecture
+
+```
+Hot Reload System
+=================
+
+FileSystemWatcher
+  - Monitors packs/ directory
+  - Filters: *.yaml, *.json
+  - Debounce: 100ms
+
+HotReloadBridge
+  - Validates changed file
+  - Unloads old content
+  - Loads new content
+  - Syncs ECS components
+
+ModuleState
+  - Tracks per-pack reload count
+  - Preserves entity mappings
+  - Handles rollback on failure
+```
+
+### 6.4 State Preservation Strategies
+
+| Strategy | Data Preserved | Implementation | Risk |
+|----------|----------------|----------------|------|
+| **Entity Mapping** | IDs | Dictionary | Low |
+| **Component Snapshot** | Values | Serialize | Medium |
+| **Full State** | Everything | Deep copy | High |
+
+---
+
+## 7. Game Automation Frameworks
+
+### 7.1 UI Automation Technologies
+
+| Framework | Platform | Method | Speed | DINOForge Status |
+|-----------|----------|--------|-------|------------------|
+| **Win32 SendInput** | Windows | Native | ~1ms | Primary |
+| **Playwright** | Cross | Browser | ~50ms | Screenshot only |
+| **AutoIt** | Windows | Native | ~5ms | Reference |
+| **PyAutoGUI** | Cross | Python | ~10ms | Reference |
+
+### 7.2 Input Injection Methods
+
+| Method | Detection | Reliability | Use Case |
+|--------|-----------|-------------|----------|
+| **SendInput API** | Low | High | General automation |
+| **DirectInput** | Low | Medium | Game controllers |
+| **Raw Input** | Low | High | Low-level input |
+| **Hardware Events** | Very Low | Very High | Undetectable |
+
+### 7.3 Game State Querying
+
+| Source | Data Type | Latency | Accuracy |
+|--------|-----------|---------|----------|
+| **ECS Queries** | Live entities | ~1ms | Perfect |
+| **Entity Dumps** | Serialized state | ~100ms | Snapshot |
+| **Memory Reading** | Raw values | ~0.1ms | Risky |
+| **Screen Capture** | Visual state | ~50ms | Interpreted |
+
+### 7.4 Automation Architecture
+
+```
+Game Automation Stack
+=====================
+
+MCP Server Layer
+  - HTTP API on port 8765
+  - JSON-RPC protocol
+  - Tool implementations
+
+Game Bridge
+  - ECS World queries
+  - Entity manipulation
+  - State serialization
+
+Input Layer
+  - SendInput API wrapper
+  - Key/mouse injection
+  - Timing controls
+
+Vision Layer (Optional)
+  - Screenshot capture
+  - OmniParser analysis
+  - UI element detection
+```
+
+---
+
+## 8. Computer Vision for Games
+
+### 8.1 Screen Analysis Technologies
+
+| Technology | Use Case | Latency | Accuracy | Cost |
+|------------|----------|---------|----------|------|
+| **OmniParser** | UI element detection | ~500ms | 90%+ | High |
+| **YOLOv8** | Object detection | ~50ms | 95% | Medium |
+| **PaddleOCR** | Text recognition | ~200ms | 92% | Low |
+| **OpenCV Template** | Fixed UI | ~5ms | 99% | None |
+| **DirectML Vision** | GPU-accelerated | ~20ms | 90% | GPU |
+
+### 8.2 Vision Pipeline
+
+```
+Screen Analysis Pipeline
+========================
+
+Screenshot Capture
+  - DXGI Desktop Duplication
+  - GDI BitBlt (fallback)
+  - Format: RGBA, PNG
+
+Preprocessing
+  - Resize if needed
+  - Normalize
+  - Region of interest
+
+Analysis
+  - Model inference
+  - Bounding boxes
+  - Confidence scores
+
+Postprocessing
+  - NMS (Non-Maximum Suppression)
+  - Label mapping
+  - Coordinate transform
+```
+
+### 8.3 OmniParser Integration
+
+OmniParser is a unified framework for parsing user interface screenshots into structured elements.
+
+| Capability | Input | Output | Use Case |
+|------------|-------|--------|----------|
+| **Icon Detection** | Screenshot | Icon labels | Button identification |
+| **Text Recognition** | Screenshot | OCR text | HUD reading |
+| **Layout Parsing** | Screenshot | Element tree | UI navigation |
+| **Action Prediction** | Screenshot | Click regions | Automation |
+
+### 8.4 DINOForge Vision Use Cases
+
+| Use Case | Method | Confidence Threshold |
+|----------|--------|---------------------|
+| **Health Bar Reading** | Template + OCR | 95% |
+| **Unit Portrait Detection** | OmniParser | 85% |
+| **Menu Navigation** | Template | 99% |
+| **Resource Counter OCR** | PaddleOCR | 90% |
+
+---
+
+## 9. Property Testing & Fuzzing
+
+### 9.1 .NET Property Testing
+
+| Framework | Type | Integration | Properties/sec |
+|-----------|------|-------------|----------------|
+| **FsCheck** | Property-based | xUnit | ~1K |
+| **Bogus** | Data generation | Any | ~10K |
+| **AutoFixture** | Object creation | xUnit | ~5K |
+
+### 9.2 Fuzzing Frameworks
+
+| Framework | Type | Coverage | Speed |
+|-----------|------|----------|-------|
+| **SharpFuzz** | Coverage-guided | AFL/libFuzzer | Variable |
+| **DotnetFuzz** | Random | Custom | Fast |
+| **Peach** | Protocol | State machine | Medium |
+
+### 9.3 DINOForge Property Tests
+
+```csharp
+// FsCheck roundtrip property
+[Property]
+public Property UnitDefinition_Roundtrip()
+{
+    return Prop.ForAll(
+        Arb.From<UnitDefinitionGenerator>(),
+        def =>
+        {
+            var yaml = YamlSerializer.Serialize(def);
+            var roundtrip = YamlSerializer.Deserialize<UnitDefinition>(yaml);
+            return roundtrip == def;
+        }
+    );
+}
+
+// Registry consistency property
+[Property]
+public Property Registry_NoDuplicateIds()
+{
+    return Prop.ForAll(
+        Arb.From<List<UnitDefinitionGenerator>>(),
+        units =>
+        {
+            var registry = new UnitRegistry();
+            foreach (var u in units)
+            {
+                var result = registry.TryRegister(u.Id, u);
+                if (!result && registry.ContainsKey(u.Id))
+                    return false;
+            }
+            return registry.Count == units.Select(u => u.Id).Distinct().Count();
+        }
+    );
+}
+```
+
+### 9.4 Fuzzing Targets
+
+| Component | Input Format | Coverage Target | Status |
+|-----------|--------------|-----------------|--------|
+| **PackCompiler** | YAML packs | All code paths | Active |
+| **SchemaValidator** | JSON/YAML | Validation branches | Active |
+| **ContentLoader** | Pack directories | Load sequences | Planned |
+| **EntityDumper** | Game memory | Dump completeness | Planned |
+
+### 9.5 Mutation Testing
+
+| Tool | Framework | Mutation Operators | Speed |
+|------|-----------|-------------------|-------|
+| **Stryker.NET** | .NET | 50+ | ~10x test time |
+
+---
+
+## 10. Multi-Instance Orchestration
+
+### 10.1 Game Instance Isolation
+
+| Isolation Level | Method | Overhead | Use Case |
+|-----------------|--------|----------|----------|
+| **Process** | Separate process | Medium | Parallel testing |
+| **Sandbox** | Windows sandbox | High | Security testing |
+| **VM** | Full VM | Very High | CI/CD |
+| **Container** | Windows container | High | Linux games |
+
+### 10.2 Duplicate Instance Detection
+
+Games often prevent multiple instances. Bypass techniques:
+
+| Method | Detection | Risk | DINOForge Approach |
+|--------|-----------|------|-------------------|
+| **Mutex bypass** | Mutex name | Low | Rename known mutexes |
+| **Window class** | Window name | Low | Randomize class names |
+| **Shared memory** | Memory maps | Medium | Isolate memory space |
+| **Registry checks** | Registry keys | Low | Virtual registry |
+
+### 10.3 Concurrent Instance Architecture
+
+```
+Multi-Instance System
+=====================
+
+Instance Manager
+  - Tracks running instances
+  - Assigns ports/IDs
+  - Monitors health
+
+Per-Instance Setup
+  - Separate game directory (or junction)
+  - Unique save path
+  - Isolated config
+  - Dedicated MCP port
+
+MCP Multi-Port
+  - Base port: 8765
+  - Instance N: 8765 + N
+  - Port discovery service
+```
+
+### 10.4 Resource Management
+
+| Resource | Per-Instance | Shared | Strategy |
+|----------|--------------|--------|----------|
+| **CPU** | 1-4 cores | - | Affinity setting |
+| **GPU** | VRAM slice | GPU compute | Frame limiting |
+| **RAM** | 2-4 GB | - | Working set |
+| **Disk** | Save files | Game files | Junction points |
+| **Network** | - | Connection | Rate limiting |
+
+---
+
+## 11. Neural Asset Generation
+
+### 11.1 Text-to-3D Technologies
+
+| Model | Input | Output | Quality | Speed |
+|-------|-------|--------|---------|-------|
+| **Shap-E** | Text | Mesh/Point cloud | Medium | Fast |
+| **Point-E** | Text | Point cloud | Low | Fast |
+| **DreamFusion** | Text | Mesh | Medium | Slow |
+| **Magic3D** | Text | Mesh | High | Slow |
+| **Rodin** | Text/Image | Mesh | High | Medium |
+
+### 11.2 Texture Generation
+
+| Model | Input | Output | Resolution | Quality |
+|-------|-------|--------|------------|---------|
+| **Stable Diffusion** | Text/Prompt | Image | 512-2048 | High |
+| **DALL-E 3** | Text | Image | 1024 | Very High |
+| **Midjourney** | Text | Image | 1024 | Artistic |
+| **Materialize** | Image | PBR Maps | 1K-4K | Good |
+
+### 11.3 Neural Animation
+
+| Technology | Input | Output | Quality | Status |
+|------------|-------|--------|---------|--------|
+| **DeepMotion** | Video | Skeletal | High | Commercial |
+| **Move.ai** | Video | Skeletal | High | Commercial |
+| **Rokoko Video** | Video | Skeletal | Medium | Commercial |
+| **MIXAMO** | Character | Animation | Good | Free tier |
+
+### 11.4 DINOForge Neural Pipeline (Future)
+
+```
+Neural Asset Pipeline
+=====================
+
+Input: Text description or reference image
+
+Stage 1: Concept Generation
+  - Stable Diffusion for concept art
+  - Iterative refinement with feedback
+
+Stage 2: 3D Generation
+  - Shap-E or Rodin for base mesh
+  - Retopology for game-ready topology
+
+Stage 3: Texture Generation
+  - UV unwrap
+  - Stable Diffusion for textures
+  - Materialize for PBR maps
+
+Stage 4: Rigging/Animation
+  - Auto-rigging tools
+  - Animation retargeting
+
+Stage 5: Integration
+  - LOD generation
+  - Unity import
+  - Addressables packaging
+```
+
+---
+
+## 12. MCP & Agent Protocols
+
+### 12.1 Model Context Protocol
+
+MCP (Model Context Protocol) is an open protocol for integrating AI assistants with external tools.
+
+| Component | Purpose | DINOForge Implementation |
+|-----------|---------|-------------------------|
+| **Server** | Tool host | McpServer.cs |
+| **Client** | AI connector | Claude Code |
+| **Tools** | Capabilities | 13+ game tools |
+| **Resources** | Data access | Pack registry |
+| **Prompts** | Templates | Slash commands |
+
+### 12.2 MCP Tools Architecture
+
+```
+MCP Server Architecture
+=======================
+
+Transport Layer
+  - HTTP/SSE on port 8765
+  - JSON-RPC 2.0 protocol
+  - Session management
+
+Tool Registry
+  - Tool definitions (name, description, schema)
+  - Handler mapping
+  - Validation
+
+Game Bridge
+  - ECS World access
+  - Entity queries
+  - State manipulation
+
+Tools Implementation
+  Query Tools:
+    - game_status, list_packs, query_entity
+    - list_units, get_component, get_registry
+    - get_logs
+  
+  Control Tools:
+    - spawn_unit, apply_override, reload_packs
+    - dump_world, run_scenario
+```
+
+### 12.3 Tool Categories
+
+| Category | Tools | Purpose |
+|----------|-------|---------|
+| **Query** | 8 tools | Inspect game state |
+| **Control** | 5 tools | Modify game state |
+| **Automation** | Via control | UI interaction |
+
+### 12.4 Agent Integration Patterns
+
+| Pattern | Trigger | Action | Example |
+|---------|---------|--------|---------|
+| **Polling** | Timer | Check status | game_status every 5s |
+| **Event** | Game event | React | On unit spawn |
+| **Command** | User request | Execute | Spawn unit X at Y |
+| **Scheduled** | Time-based | Batch | Nightly tests |
+
+---
+
+## 13. Cross-Platform Considerations
+
+### 13.1 Platform Support Matrix
+
+| Platform | Game | Mod Loader | DINOForge Status |
+|----------|------|------------|------------------|
+| **Windows** | Yes | BepInEx | Primary |
+| **Linux** | Proton | BepInEx | Compatible |
+| **macOS** | No | N/A | N/A |
+
+### 13.2 Proton/Wine Compatibility
+
+| Component | Proton Status | Notes |
+|-------------|---------------|-------|
+| **Game** | Platinum | Works perfectly |
+| **BepInEx** | Gold | Minor tweaks needed |
+| **MCP Server** | Gold | Port binding |
+| **Desktop Companion** | Silver | WinUI 3 limitation |
+
+### 13.3 Platform-Specific Code
+
+| Feature | Windows | Linux | macOS |
+|---------|---------|-------|-------|
+| **Input Injection** | SendInput | XTest | N/A |
+| **Screenshot** | DXGI | X11/DBus | N/A |
+| **Process Control** | Win32 API | procfs | N/A |
+| **Registry** | Native | Wine registry | N/A |
+
+---
+
+## 14. Security & Anti-Cheat
+
+### 14.1 Anti-Cheat Systems
+
+| System | Detection Method | Mod Risk | DINOForge Approach |
+|--------|-----------------|----------|-------------------|
+| **EAC (Easy Anti-Cheat)** | Kernel driver | High | Single-player only |
+| **BattlEye** | Kernel driver | High | Single-player only |
+| **VAC** | Signature + Heuristic | Medium | No multiplayer mods |
+| **Custom** | Variable | Variable | Case-by-case |
+
+### 14.2 DINOForge Security Model
+
+```
+Security Layers
+===============
+
+1. Game Selection
+   - Only single-player/co-op games
+   - No competitive multiplayer
+   - Respect EULAs
+
+2. Mod Isolation
+   - Pack sandboxing
+   - No executable code in packs
+   - Schema validation prevents injection
+
+3. Runtime Safety
+   - ECS component bounds checking
+   - No memory manipulation
+   - Read-heavy, write-light
+
+4. Distribution
+   - Open source
+   - No obfuscation
+   - Transparent operation
+```
+
+### 14.3 Safe Modding Practices
+
+| Practice | Implementation | Benefit |
+|----------|----------------|---------|
+| **Declarative Content** | YAML configs | No code injection |
+| **Schema Validation** | JSON Schema | Structure enforcement |
+| **Registry Boundaries** | Typed registries | Type safety |
+| **Component Sandboxing** | Bridge pattern | Isolated writes |
+
+---
+
+## 15. Community & Distribution
+
+### 15.1 Mod Distribution Platforms
+
+| Platform | Unity Support | Features | DINOForge Status |
+|----------|-------------|----------|------------------|
+| **Steam Workshop** | Native | Auto-update, ratings | Research |
+| **Thunderstore** | Good | Dependency mgmt | Compatible |
+| **Nexus Mods** | Good | Community, Vortex | Compatible |
+| **CurseForge** | Good | Wide reach | Compatible |
+| **Mod.io** | API | Cross-platform | Future |
+| **GitHub Releases** | Manual | Version control | Primary |
+
+### 15.2 Pack Distribution Format
+
+```
+DINOForge Pack Distribution
+============================
+
+Format: .zip or .dinopack
+
+Contents:
+  pack.yaml          - Manifest
+  content/           - YAML content files
+    units/
+    buildings/
+    factions/
+  assets/            - Asset bundles (optional)
+    *.bundle
+    catalog.json
+  README.md          - Documentation
+  LICENSE            - License file
+```
+
+### 15.3 Version Management
+
+| Strategy | Pros | Cons | DINOForge Use |
+|----------|------|------|---------------|
+| **Semantic Versioning** | Clear compatibility | Manual bumping | Primary |
+| **Auto-increment** | Simple | No meaning | Build numbers |
+| **Git SHA** | Exact tracking | Hard to read | Debug info |
+| **Date-based** | Chronological | No compatibility | Not used |
+
+### 15.4 Update Mechanisms
+
+| Mechanism | Trigger | User Action | Status |
+|-----------|---------|-------------|--------|
+| **Manual Download** | User checks | Download, extract | Supported |
+| **Git Submodule** | Pack update | git pull | Supported |
+| **Companion Update** | Check on launch | Click update | Supported |
+| **Steam Workshop** | Auto | None | Planned |
+| **In-game Check** | Periodic | Prompt | Future |
+
+---
+
+## Appendix A: Performance Benchmarks
+
+### A.1 ECS Query Performance
+
+| Entity Count | Query Time | Memory |
+|--------------|------------|--------|
+| 100 | 0.01ms | 10KB |
+| 1,000 | 0.1ms | 100KB |
+| 10,000 | 1ms | 1MB |
+| 100,000 | 10ms | 10MB |
+
+### A.2 Pack Loading Performance
+
+| Pack Size | Parse | Validate | Register | Total |
+|-----------|-------|----------|----------|-------|
+| 10 units | 5ms | 10ms | 5ms | 20ms |
+| 100 units | 20ms | 50ms | 25ms | 95ms |
+| 500 units | 80ms | 200ms | 100ms | 380ms |
+
+### A.3 MCP Response Times
+
+| Tool | Min | Max | Avg |
+|------|-----|-----|-----|
+| game_status | 5ms | 20ms | 10ms |
+| spawn_unit | 30ms | 100ms | 50ms |
+| query_entity | 10ms | 50ms | 20ms |
+| screenshot | 50ms | 200ms | 100ms |
+
+---
+
+## Appendix B: Technology Roadmap
+
+### 2024-2025 (Current)
+- BepInEx 5.4.x integration
+- Unity ECS 1.0 support
+- YAML declarative content
+- MCP server protocol
+- Desktop Companion (WinUI 3)
+
+### 2025-2026 (Near-term)
+- Unity ECS 1.1 support
+- glTF import pipeline
+- Enhanced MCP tools
+- Steam Workshop integration
+- Linux native support
+
+### 2026-2027 (Future)
+- Neural asset generation
+- AI-assisted balancing
+- Cloud pack distribution
+- Multiplayer sync (co-op)
+- Advanced vision automation
+
+---
+
+## Appendix C: Glossary
+
+| Term | Definition |
+|------|------------|
+| **AOT** | Ahead-of-Time compilation |
+| **Archetype** | ECS entity type based on component set |
+| **BC** | Block Compression (texture format) |
+| **ECS** | Entity Component System |
+| **IL2CPP** | Unity AOT compiler |
+| **JIT** | Just-in-Time compilation |
+| **LOD** | Level of Detail |
+| **MCP** | Model Context Protocol |
+| **PBR** | Physically Based Rendering |
+| **SoA** | Structure of Arrays |
+| **YAML** | YAML Ain't Markup Language |
+
+---
+
+## Appendix D: Comparative Analysis
+
+### D.1 Mod Platform Comparison
+
+| Platform | Engine | Mod Format | Distribution | Automation | Community |
+|----------|--------|------------|--------------|------------|-----------|
+| **DINOForge** | Unity ECS | YAML Packs | GitHub/Workshop | MCP Server | Growing |
+| **Cities: Skylines** | Unity | C# + Assets | Steam Workshop | Limited | Large |
+| **Kerbal Space Program** | Unity | CFG + Assets | Manual/CKAN | Limited | Large |
+| **RimWorld** | Unity | XML + C# | Steam Workshop | Limited | Large |
+| **Factorio** | Custom | Lua | In-game/Portal | Mod API | Large |
+| **Stellaris** | Clausewitz | TXT + LUA | Steam Workshop | Limited | Large |
+| **Skyrim/Fallout** | Creation Engine | ESP/ESL | Nexus/Steam | SKSE | Massive |
+| **Minecraft** | Java/Bedrock | Java/JSON | CurseForge | Forge API | Massive |
+| **Tabletop Simulator** | Unity | JSON + Assets | Steam Workshop | Lua API | Medium |
+| **Unity Mods (Generic)** | Unity | C# DLL | Thunderstore | BepInEx | Varies |
+
+### D.2 Content Format Comparison
+
+| Format | Human Readable | Version Control | Validation | Tooling | DINOForge |
+|--------|----------------|-----------------|------------|---------|-----------|
+| **YAML** | Excellent | Good | JSON Schema | Good | Primary |
+| **JSON** | Good | Excellent | JSON Schema | Excellent | Secondary |
+| **XML** | Poor | Good | XSD/DTD | Excellent | Not used |
+| **TOML** | Excellent | Good | Limited | Fair | Future |
+| **Lua** | Fair | Good | Runtime | Good | Reference |
+| **C#** | N/A | Excellent | Compiler | Excellent | Runtime |
+| **INI** | Good | Poor | None | Poor | Not used |
+
+### D.3 Automation Capability Matrix
+
+| Platform | State Query | Entity Control | UI Automation | Screenshot | API |
+|----------|-------------|----------------|---------------|------------|-----|
+| **DINOForge** | Full ECS | Full | SendInput | Yes | MCP |
+| **Unity ML-Agents** | Limited | Training | Gym API | Yes | Python |
+| **OpenAI Universe** | Pixel | Gym | VNC | Yes | Python |
+| **Gymnasium** | Varies | Varies | Varies | Optional | Python |
+| **MineRL** | Limited | Actions | Script | Yes | Python |
+| **AI2-THOR** | Full | Full | Unity | Yes | Python |
+| **Habitat** | Full | Full | Simulation | Yes | Python |
+
+---
+
+## Appendix E: Deep Dive - Unity Internals
+
+### E.1 Mono Runtime Internals
+
+```
+Mono Runtime Architecture
+=========================
+
+Execution Engine
+├── JIT Compiler
+│   ├── IL → Native code
+│   ├── Optimizations
+│   └── Method caching
+├── Garbage Collector
+│   ├── Boehm-Demers-Weiser
+│   ├── Generational
+│   └── Write barriers
+├── Threading
+│   ├── Managed threads
+│   ├── Native threads
+│   └── Thread pool
+└── Type System
+    ├── Reflection
+    ├── Generics
+    └── P/Invoke
+
+Modding Hook Points
+├── Assembly.Load events
+├── JIT compile callbacks
+├── Method trampolines
+└── VTable modifications
+```
+
+### E.2 IL2CPP Internals
+
+```
+IL2CPP Compilation Pipeline
+===========================
+
+Input: .NET DLL (IL)
+    ↓
+IL2CPP Compiler
+├── IL parsing
+├── Type analysis
+├── Generic instantiation
+└── C++ code generation
+    ↓
+Output: C++ source
+    ↓
+Platform Compiler (Clang/MSVC)
+├── Optimization
+├── Code generation
+└── Linking
+    ↓
+Output: Native executable
+
+Modding Challenges
+├── No JIT (no runtime code gen)
+├── Stripped metadata
+├── Symbol resolution
+└── Platform-specific binaries
+```
+
+### E.3 Unity Memory Management
+
+| Allocator | Purpose | Lifetime | Modding Impact |
+|-----------|---------|----------|----------------|
+| **Native** | Engine internals | Manual | Read-only |
+| **Managed** | C# objects | GC | Primary target |
+| **Temp** | Frame data | 1 frame | Read-only |
+| **Persistent** | Asset data | Explicit | Asset injection |
+| **NativeArray** | Burst/Jobs | Explicit | ECS bridge |
+
+### E.4 Unity Job System
+
+| Job Type | Thread | Burst | Use Case |
+|----------|--------|-------|----------|
+| **IJob** | Worker | Yes | Simple parallel |
+| **IJobParallelFor** | Workers | Yes | Batch processing |
+| **IJobEntity** | Workers | Yes | ECS processing |
+| **JobHandle.CombineDependencies** | - | - | Dependency mgmt |
+
+---
+
+## Appendix F: Technology Deep Dives
+
+### F.1 BepInEx Hooking Deep Dive
+
+#### MonoMod.RuntimeDetour
+
+```
+Detour Architecture
+===================
+
+Original Method
+├── Prolog
+├── Body
+└── Epilog
+    ↓
+Detour Apply
+├── Backup original
+├── Rewrite prolog
+│   └── Jump to trampoline
+├── Create trampoline
+│   ├── Backup bytes
+│   ├── Jump to hook
+│   └── Continue original
+└── Hook method
+    └── Custom logic
+
+Types of Hooks
+├── Prefix: Run before original
+├── Postfix: Run after original
+├── Transpiler: Modify IL
+├── Finalizer: Exception handling
+└── Reverse: Call original from hook
+```
+
+#### Harmony X Patches
+
+| Patch Type | Timing | Use Case |
+|------------|--------|----------|
+| **Prefix** | Before method | Prevent execution, modify args |
+| **Postfix** | After method | Modify result, side effects |
+| **Transpiler** | IL rewrite | Change method body |
+| **Finalizer** | Exception catch | Cleanup, logging |
+| **Reverse Patch** | Call original | Access original from hook |
+
+### F.2 ECS Deep Dive
+
+#### Archetype Chunk Layout
+
+```
+Chunk Memory Layout (16KB)
+===========================
+
+Header
+├── Entity count
+├── Capacity
+├── Archetype pointer
+└── Chunk index
+
+Component Arrays (SoA)
+├── Position[capacity]
+├── Rotation[capacity]
+├── Health[capacity]
+├── UnitId[capacity]
+└── ...
+
+Entity Index
+├── Index → Chunk + Offset
+└── Generation for safety
+
+Access Patterns
+├── Sequential: Cache-friendly
+├── Random: Cache misses
+├── Burst compiled: SIMD
+└── Job parallel: Multi-core
+```
+
+#### System Execution Order
+
+```
+System Groups
+=============
+
+InitializationSystemGroup
+├── BeginInitializationEntityCommandBufferSystem
+├── [Initialization systems]
+└── EndInitializationEntityCommandBufferSystem
+
+SimulationSystemGroup
+├── BeginSimulationEntityCommandBufferSystem
+├── FixedStepSimulationSystemGroup
+│   ├── [Physics systems]
+│   └── [Fixed update systems]
+├── [Simulation systems]
+└── EndSimulationEntityCommandBufferSystem
+
+PresentationSystemGroup
+├── [Presentation systems]
+└── [Rendering systems]
+
+Mod System Injection
+├── Before/After attributes
+├── UpdateInGroup attribute
+└── System ordering constraints
+```
+
+### F.3 Addressables Deep Dive
+
+#### Asset Provider Flow
+
+```
+Asset Loading Flow
+==================
+
+Request: LoadAssetAsync<T>("key")
+    ↓
+Catalog Lookup
+├── Hash → Bundle location
+├── Dependencies check
+└── Cache status
+    ↓
+Cache Check
+├── Local: Load directly
+├── Remote: Download
+└── Streaming: Stream
+    ↓
+Bundle Load
+├── Decompress (LZ4/LZMA)
+├── Load objects
+└── Reference counting
+    ↓
+Asset Return
+├── Type cast
+├── Dependency tracking
+└── Release handle
+
+Release Flow
+├── Decrement refs
+├── Unload if zero
+└── Bundle cleanup
+```
+
+### F.4 Neural Generation Models
+
+#### Text-to-3D Evolution
+
+| Model | Year | Resolution | Quality | Speed | Open Source |
+|-------|------|------------|---------|-------|-------------|
+| **DreamFields** | 2022 | NeRF | Low | Slow | Yes |
+| **DreamFusion** | 2022 | NeRF | Medium | Slow | Partial |
+| **Magic3D** | 2023 | Mesh | High | Slow | No |
+| **Rodin** | 2023 | Mesh | High | Fast | API |
+| **Wonder3D** | 2023 | Mesh | Medium | Fast | Yes |
+| **CRM** | 2024 | Mesh | High | Fast | Yes |
+| **InstantMesh** | 2024 | Mesh | High | Fast | Yes |
+| **Trellis** | 2024 | Mesh | Very High | Fast | Yes |
+
+#### Diffusion Model Comparison
+
+| Model | Resolution | Speed | License | Best For |
+|-------|------------|-------|---------|----------|
+| **SD 1.5** | 512 | Fast | Open | General |
+| **SDXL** | 1024 | Medium | Open | Quality |
+| **SD 3** | 1024 | Medium | Open | Text accuracy |
+| **DALL-E 3** | 1024 | API | Closed | Prompt following |
+| **Midjourney** | 1024 | API | Commercial | Artistic |
+| **Flux** | 1024 | Medium | Open | Best open quality |
+
+---
+
+## Appendix G: Benchmark Methodology
+
+### G.1 ECS Performance Testing
+
+```csharp
+// Entity spawn benchmark
+[Benchmark]
+public void SpawnEntities()
+{
+    var archetype = EntityManager.CreateArchetype(
+        ComponentType.ReadWrite<Position>(),
+        ComponentType.ReadWrite<Health>(),
+        ComponentType.ReadWrite<UnitId>()
+    );
+    
+    var entities = new NativeArray<Entity>(EntityCount, Allocator.Temp);
+    EntityManager.CreateEntity(archetype, entities);
+    entities.Dispose();
+}
+
+// Query performance benchmark
+[Benchmark]
+public void QueryEntities()
+{
+    var query = EntityManager.CreateEntityQuery(
+        ComponentType.ReadOnly<Health>(),
+        ComponentType.ReadOnly<UnitId>()
+    );
+    
+    var entities = query.ToEntityArray(Allocator.Temp);
+    entities.Dispose();
+}
+```
+
+### G.2 Pack Loading Benchmarks
+
+| Metric | Tool | Command |
+|--------|------|---------|
+| Parse time | PackCompiler | `packcompiler benchmark parse` |
+| Validate time | PackCompiler | `packcompiler benchmark validate` |
+| Load time | PackCompiler | `packcompiler benchmark load` |
+| Memory usage | dotMemory | Profile pack loading |
+
+### G.3 MCP Performance Testing
+
+```python
+# MCP benchmark script
+import asyncio
+import time
+from mcp import ClientSession
+
+async def benchmark_tool(session, tool_name, iterations=100):
+    times = []
+    for _ in range(iterations):
+        start = time.time()
+        await session.call_tool(tool_name, {})
+        times.append(time.time() - start)
+    
+    return {
+        "min": min(times) * 1000,
+        "max": max(times) * 1000,
+        "avg": sum(times) / len(times) * 1000
+    }
+```
+
+---
+
+## Appendix H: Case Studies
+
+### H.1 Star Wars Pack Development
+
+**Timeline**: 6 weeks  
+**Team**: 1 developer (agent-driven)  
+**Scope**: 28 units, 10 buildings, 2 factions
+
+| Phase | Duration | Key Activities |
+|-------|----------|----------------|
+| Research | 1 week | Asset sourcing, reference gathering |
+| Asset Import | 2 weeks | FBX import, LOD generation, texturing |
+| Content Definition | 1 week | YAML definitions, balance tuning |
+| Integration | 1 week | Addressables, prefab linking |
+| Testing | 1 week | Playtesting, bug fixes |
+
+**Technologies Used**:
+- AssetStudio for asset extraction
+- Blender for retopology
+- Materialize for PBR maps
+- Unity Addressables for packaging
+
+**Lessons Learned**:
+- LOD generation critical for performance
+- YAML validation saves debugging time
+- Addressables catalog needs optimization
+- Hot reload essential for iteration speed
+
+### H.2 MCP Server Implementation
+
+**Timeline**: 2 weeks  
+**Components**: 13 tools, HTTP transport, game bridge
+
+| Component | Lines of Code | Complexity |
+|-----------|---------------|------------|
+| Transport layer | 300 | Medium |
+| Game bridge | 500 | High |
+| Tool implementations | 800 | Medium |
+| Protocol handling | 200 | Low |
+
+**Key Decisions**:
+- HTTP over stdio for persistence
+- JSON-RPC 2.0 for compatibility
+- Game bridge abstraction for testability
+
+**Performance Results**:
+- Average latency: 20ms
+- Throughput: 50 req/s
+- Memory overhead: 10MB
+
+### H.3 Multi-Instance Testing System
+
+**Timeline**: 3 weeks  
+**Capability**: 10 concurrent instances
+
+| Feature | Implementation | Status |
+|---------|----------------|--------|
+| Directory isolation | Junction points | Working |
+| Mutex bypass | Renamed handles | Working |
+| Port allocation | Dynamic range | Working |
+| MCP multiplexing | Registry-based | In progress |
+
+---
+
+## Appendix I: Security Considerations
+
+### I.1 Mod Security Model
+
+| Layer | Threat | Mitigation |
+|-------|--------|------------|
+| **Pack loading** | Malicious YAML | Schema validation, no code exec |
+| **Asset loading** | Malicious assets | Unity sandbox, addressables |
+| **Runtime** | Memory corruption | ECS bridge, read-heavy |
+| **Network** | MCP exploits | Localhost only, auth future |
+
+### I.2 Anti-Cheat Compatibility
+
+| Anti-Cheat | Compatibility | Notes |
+|------------|---------------|-------|
+| **EAC** | No | Kernel driver conflicts |
+| **BattlEye** | No | Kernel driver conflicts |
+| **VAC** | Single-player | Multiplayer not supported |
+| **None** | Yes | Full functionality |
+
+---
+
+## Appendix J: Future Research Directions
+
+### J.1 Emerging Technologies
+
+| Technology | Maturity | Potential Impact |
+|------------|----------|------------------|
+| **Unity ECS 2.0** | Alpha | Performance improvements |
+| **DOTS NetCode** | Beta | Multiplayer modding |
+| **WebGPU** | Early | Web-based modding tools |
+| **WebTransport** | Draft | Alternative MCP transport |
+| **WebNN** | Draft | Browser-based neural inference |
+
+### J.2 Research Areas
+
+1. **Automated Balancing**: Genetic algorithms for unit balance
+2. **Procedural Content**: Infinite map generation
+3. **AI Opponents**: LLM-driven NPC behavior
+4. **Cross-Game Mods**: Shared content across Unity games
+5. **VR/AR Modding**: Immersive mod development
+
+---
+
+*End of Research Document*
+
+---
+
+*This research document is a living survey of the game modding landscape. Updates are made as technologies evolve.*

--- a/docs/worklogs/README.md
+++ b/docs/worklogs/README.md
@@ -1,0 +1,59 @@
+# Work Audit — Dino
+
+
+**Category: ARCHITECTURE**
+**Index:** See `/Users/kooshapari/CodeProjects/Phenotype/repos/worklogs/README.md`
+
+## Purpose
+
+This log records research completions, architectural decisions, issues discovered (duplication, performance, governance), work completions, and planning artifacts (fork candidates, migration plans) for Dino.
+
+## Worklog Categories
+
+All entries MUST be organized into one of these categories:
+
+| Category | File | Purpose |
+|----------|------|---------|
+| ARCHITECTURE | worklogs/ARCHITECTURE.md | ADRs, library extraction, major refactors |
+| DUPLICATION | worklogs/DUPLICATION.md | Cross-project code duplication |
+| DEPENDENCIES | worklogs/DEPENDENCIES.md | External deps, forks, modernization |
+| INTEGRATION | worklogs/INTEGRATION.md | External integrations, bridge contracts |
+| PERFORMANCE | worklogs/PERFORMANCE.md | Optimization, benchmarking, profiling |
+| RESEARCH | worklogs/RESEARCH.md | Starred repo analysis, technology research |
+| GOVERNANCE | worklogs/GOVERNANCE.md | Policy, evidence, quality gates, process |
+
+## When to Write
+
+Write an entry for:
+- Research completions (starred repos, tech eval, design exploration)
+- Significant decisions made (why we chose X over Y)
+- Issues found (duplication >50 LOC, performance bottlenecks, governance gaps)
+- Work completions (feature shipped, large refactor finished)
+- Planning (fork candidates, migration roadmaps, deprecation notices)
+
+## Format
+
+Each entry should include:
+- **Date** (YYYY-MM-DD)
+- **Category** (from table above)
+- **Title** (concise, searchable)
+- **Context** (what prompted this work)
+- **Finding/Decision** (what was discovered or decided)
+- **Impact** (how it affects this project or others)
+- **Project Tags** (e.g., `Dino`, `[cross-repo]`)
+
+## Example
+
+```markdown
+### 2026-04-24 | DUPLICATION | Config loader duplication in 5 projects
+
+**Context:** Cross-project audit identified identical config loading patterns.
+**Finding:** 50+ LOC duplicated in BytePort, Civis, Dino, Eidolon, FocalPoint.
+**Decision:** Extract into phenotype-config-core shared crate.
+**Impact:** -250 LOC across 5 repos; single source of truth for config.
+**Tags:** `[cross-repo]` `[DUPLICATION]`
+```
+
+---
+
+See parent worklog index at `/Users/kooshapari/CodeProjects/Phenotype/repos/worklogs/README.md` for aggregation tools and cross-project analysis.

--- a/worklog.md
+++ b/worklog.md
@@ -1,0 +1,22 @@
+# Dino Worklog
+
+## Recent Entries
+
+### %Y->- (HEAD -> main) — GOVERNANCE
+
+**docs(fr): scaffold FUNCTIONAL_REQUIREMENTS.md**
+
+Device automation toolkit requirements scaffolded for specification alignment.
+
+---
+
+## Categories
+
+- **ARCHITECTURE**: ADRs, library extraction, design patterns
+- **DUPLICATION**: Cross-project duplication identification
+- **DEPENDENCIES**: External deps, forks, modernization
+- **INTEGRATION**: External integrations, MCP, plugins
+- **PERFORMANCE**: Optimization, benchmarking
+- **RESEARCH**: Starred repo analysis, audits
+- **GOVERNANCE**: Policy, evidence, quality gates
+


### PR DESCRIPTION
## Summary
- add Dino governance/spec documents and worklog index
- add ADR-020 through ADR-022 and update ADR index
- add FR coverage matrix and mod-platform research docs

## Scope
- docs-only lane
- intentionally excludes src/SDK and tests/smoke.test.ts for a separate implementation PR

## Validation
- git diff --check
- conflict-marker scan

Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only additions; low risk aside from potential confusion if this documentation diverges from current implementation or future plans.
> 
> **Overview**
> Adds a **governance/spec documentation pack**: new top-level `CHARTER.md`, `PRD.md`, `SPEC.md`, and an `ADR.md` ADR process/index document.
> 
> Introduces three new proposed ADRs—`ADR-020` (multi-instance concurrency), `ADR-021` (neural asset pipeline), and `ADR-022` (MCP orchestration)—and updates `docs/adr/index.md` to include them.
> 
> Adds a placeholder `docs/reference/fr_coverage_matrix.md` for *FR-to-test traceability* tracking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d02684ad81a76e83c29607d54379c6b7ca322b8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->