### PR TITLE
chore(gitignore): exclude rust target + python cache (Scorecard FP cleanup)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,11 @@ packages.lock.json
 
 # Coverage reports
 src/Tests/coverage.cobertura.xml
+
+# Rust build outputs (Scorecard BinaryArtifacts FP cleanup)
+target/
+
+# Python cache (Scorecard BinaryArtifacts FP cleanup)
+__pycache__/
+*.pyc
+*.pyo


### PR DESCRIPTION
Add target/, __pycache__/, *.pyc, *.pyo to .gitignore to prevent future commits flagged by Scorecard BinaryArtifacts (12 alerts).

Note: existing committed files require git-filter-repo to remove from history; this PR only prevents future commits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts ignore rules and does not affect runtime behavior or build logic; impact is limited to which generated files can be accidentally committed.
> 
> **Overview**
> Prevents future commits of generated build artifacts by expanding `.gitignore` to exclude top-level Rust build outputs (`target/`) and Python bytecode/cache files (`__pycache__/`, `*.pyc`, `*.pyo`).
> 
> This complements the existing tool-specific ignores (e.g., `src/Tools/AssetPipelineRust/target/`) to reduce BinaryArtifacts/Scorecard findings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa3c315bc1b1a2252d863e3cae499df259713d50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->