### PR TITLE
chore(codeql): pin actions to SHA (PinnedDependencies wave 1)

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -17,8 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-dotnet@v5
-        with:
+      - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5with:
           dotnet-version: '11.0.x'
       - name: Install DocFX
         run: dotnet tool install -g docfx

--- a/.github/workflows/asset-pipeline.yml
+++ b/.github/workflows/asset-pipeline.yml
@@ -20,8 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@v5
-        with:
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5with:
           global-json-file: global.json
 
       - name: Restore dependencies
@@ -69,8 +68,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6with:
           node-version: 22
 
       - name: Install dependencies
@@ -91,7 +89,6 @@ jobs:
 
       - name: Deploy to GitHub Pages
         if: steps.check-vitepress.outputs.has-package-json == 'true'
-        uses: peaceiris/actions-gh-pages@v4
-        with:
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/.vitepress/dist

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -16,8 +16,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5with:
           dotnet-version: |
             8.0.x
           global-json-file: global.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5with:
           dotnet-version: |
             8.0.x
           global-json-file: global.json
@@ -61,8 +60,7 @@ jobs:
         run: dotnet test src/Tests/Integration/DINOForge.Tests.Integration.csproj --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=integration-test-results.trx"
 
       - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5with:
           python-version: '3.10'
           cache: 'pip'
           cache-dependency-path: 'src/Tools/DinoforgeMcp/pyproject.toml'
@@ -130,12 +128,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-        with:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4with:
           fetch-depth: 0  # SonarCloud needs full history for blame analysis
 
-      - uses: SonarSource/sonarcloud-github-action@v3
-        with:
+      - uses: SonarSource/sonarcloud-github-action@383f7e52eae3ab0510c3cb0e7d9d150bbaeab838 # v3with:
           projectBaseDir: .
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,14 +25,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5with:
           dotnet-version: 8.0.x
           global-json-file: global.json
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
+        uses: github/codeql-action/init@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3with:
           languages: csharp
 
       - name: Restore dependencies
@@ -54,6 +52,5 @@ jobs:
           dotnet build src/DINOForge.CI.NoRuntime.sln -c Release --no-restore /p:BuildInParallel=false
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
-        with:
+        uses: github/codeql-action/analyze@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3with:
           category: "/language:csharp"

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -10,10 +10,7 @@ jobs:
     name: FsCheck Property Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-dotnet@v5
-        with:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4- uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5with:
           dotnet-version: |
             8.0.x
           global-json-file: global.json
@@ -49,8 +46,7 @@ jobs:
 
       - name: Upload property test results
         if: always()
-        uses: actions/upload-artifact@v4
-        with:
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4with:
           name: property-test-results
           path: TestResults/Property/
 
@@ -58,10 +54,7 @@ jobs:
     name: Fuzz Target Smoke Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-dotnet@v5
-        with:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4- uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5with:
           dotnet-version: |
             8.0.x
           global-json-file: global.json
@@ -97,8 +90,7 @@ jobs:
 
       - name: Upload fuzz smoke test results
         if: always()
-        uses: actions/upload-artifact@v4
-        with:
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4with:
           name: fuzz-smoke-results
           path: TestResults/FuzzSmoke/
 
@@ -106,9 +98,7 @@ jobs:
     name: Validate Fuzz Corpus Files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Check corpus files exist
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4- name: Check corpus files exist
         run: |
           set -e
           echo "Validating fuzz corpus structure..."

--- a/.github/workflows/game-automation.yml
+++ b/.github/workflows/game-automation.yml
@@ -44,13 +44,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4with:
           dotnet-version: '11.0.x'
           include-prerelease: true
 
@@ -159,8 +157,7 @@ jobs:
 
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@v4
-        with:
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4with:
           name: game-automation-screenshots-${{ matrix.instances }}-instances
           path: docs/automation/screenshots/
           retention-days: 7
@@ -168,8 +165,7 @@ jobs:
 
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@v4
-        with:
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4with:
           name: game-automation-logs-${{ matrix.instances }}-instances
           path: |
             docs/automation/logs/

--- a/.github/workflows/game-launch-validation.yml
+++ b/.github/workflows/game-launch-validation.yml
@@ -16,11 +16,8 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup .NET 11
-        uses: actions/setup-dotnet@v4
-        with:
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4- name: Setup .NET 11
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4with:
           dotnet-version: '11.0.100-preview.2.26159.112'
           include-prerelease: true
 
@@ -91,8 +88,7 @@ jobs:
 
       - name: Upload failure artifacts
         if: failure() && github.event_name != 'pull_request'
-        uses: actions/upload-artifact@v4
-        with:
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4with:
           name: game-launch-failures
           path: |
             ${{ env.TEMP }}\DINOForge\failures\
@@ -103,8 +99,7 @@ jobs:
 
       - name: Comment on PR with failure analysis
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7with:
           script: |
             const fs = require('fs');
             const tempDir = `${{ env.TEMP }}\\DINOForge\\failures`;

--- a/.github/workflows/game-launch.yml
+++ b/.github/workflows/game-launch.yml
@@ -27,8 +27,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5with:
           dotnet-version: 11.0.x
 
       - name: Build bridge client

--- a/.github/workflows/journey-quality-gates.yml
+++ b/.github/workflows/journey-quality-gates.yml
@@ -13,8 +13,7 @@ jobs:
   validate-journeys:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4with:
           submodules: true
       
       - name: Validate journey manifest structure
@@ -73,9 +72,7 @@ jobs:
   manifest-count:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      
-      - name: Report manifest count
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4- name: Report manifest count
         run: |
           count=$(find docs/journeys/manifests -name manifest.json | wc -l)
           echo "Total journey manifests: $count"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,8 +19,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5with:
           global-json-file: global.json
 
       - name: Restore dependencies
@@ -35,12 +34,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-        with:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4with:
           fetch-depth: 0
 
-      - uses: SonarSource/sonarcloud-github-action@v3
-        with:
+      - uses: SonarSource/sonarcloud-github-action@383f7e52eae3ab0510c3cb0e7d9d150bbaeab838 # v3with:
           projectBaseDir: .
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/mcp-pytest.yml
+++ b/.github/workflows/mcp-pytest.yml
@@ -23,11 +23,8 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4- name: Set up Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4with:
           python-version: ${{ matrix.python-version }}
           cache: pip
 
@@ -51,16 +48,14 @@ jobs:
             --junit-xml=test-results.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
-        with:
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6with:
           files: ./src/Tools/DinoforgeMcp/coverage.json
           flags: mcp-server
           name: mcp-server-coverage
           fail_ci_if_error: false
 
       - name: Upload test results
-        uses: actions/upload-artifact@v3
-        if: always()
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3if: always()
         with:
           name: test-results-${{ matrix.python-version }}
           path: |
@@ -68,8 +63,7 @@ jobs:
             src/Tools/DinoforgeMcp/htmlcov/
 
       - name: Publish test report
-        uses: dorny/test-reporter@v3
-        if: always()
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3if: always()
         with:
           name: Pytest Results (Python ${{ matrix.python-version }})
           path: src/Tools/DinoforgeMcp/test-results.xml
@@ -95,11 +89,8 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4- name: Set up Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4with:
           python-version: "3.11"
           cache: pip
 
@@ -137,11 +128,8 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4- name: Set up Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4with:
           python-version: "3.11"
           cache: pip
 
@@ -166,9 +154,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
-
-      - name: Generate summary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8- name: Generate summary
         run: |
           echo "## MCP Server Test Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -18,8 +18,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5with:
           dotnet-version: |
             8.0.x
           global-json-file: global.json

--- a/.github/workflows/polyglot-build.yml
+++ b/.github/workflows/polyglot-build.yml
@@ -54,8 +54,7 @@ jobs:
           targets: ${{ matrix.rust-target }}
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2with:
           workspaces: src/Tools/AssetPipelineRust
 
       - name: Build Rust library (release)
@@ -113,8 +112,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5with:
           go-version: '1.22'
           cache: true
           cache-dependency-path: src/Tools/DependencyResolver/go.sum
@@ -177,8 +175,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Zig
-        uses: goto-bus-stop/setup-zig@v2
-        with:
+        uses: goto-bus-stop/setup-zig@{"message":"Not Found","documentation_url":"https://docs.github.com/rest/git/refs#get-a-reference","status":"404"} # v2with:
           version: master
 
       - name: Run Zig tests
@@ -231,8 +228,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: 'src/Tools/DinoforgeMcp/pyproject.toml'
@@ -274,8 +270,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2with:
           workspaces: /tmp/playcua
 
       - name: Build PlayCUA (release)
@@ -384,8 +379,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4with:
           dotnet-version: '11.0.100-preview.2'
           include-prerelease: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,7 @@ jobs:
 
       # Install all required SDKs: net8.0 (SDK/Domains/Tests) + net11.0 (Tools/CLI)
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5with:
           dotnet-version: |
             8.0.x
             11.0.x
@@ -370,8 +369,7 @@ jobs:
       # Build Go DependencyResolver binary
       # ---------------------------------------------------------------
       - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5with:
           go-version: '1.22'
 
       - name: Build Go DependencyResolver (Windows)
@@ -724,8 +722,7 @@ jobs:
 
       # Upload Desktop Companion (optional — skipped if VS Build Tools unavailable)
       - name: Upload Desktop Companion
-        uses: actions/upload-artifact@v4
-        with:
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4with:
           name: desktop-companion
           path: |
             staging/DINOForge.Companion-v${{ steps.version.outputs.VERSION }}-win-x64.zip

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -20,8 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v5 
-        with:
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5with:
           global-json-file: global.json
 
       - name: Install CycloneDX tool

--- a/.github/workflows/security-guard.yml
+++ b/.github/workflows/security-guard.yml
@@ -25,8 +25,7 @@ jobs:
           build-mode: manual
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5with:
           global-json-file: global.json
 
       - name: Restore dependencies
@@ -62,8 +61,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5with:
           global-json-file: global.json
 
       - name: Restore dependencies

--- a/.github/workflows/ui-automation.yml
+++ b/.github/workflows/ui-automation.yml
@@ -22,8 +22,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5with:
           dotnet-version: 11.0.x
           cache: true
           cache-dependency-path: "**/packages.lock.json"

--- a/.github/workflows/validate-packs.yml
+++ b/.github/workflows/validate-packs.yml
@@ -29,8 +29,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup .NET 8.0
-        uses: actions/setup-dotnet@v5
-        with:
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5with:
           global-json-file: global.json
 
       - name: Restore dependencies

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -25,8 +25,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup .NET 8
-        uses: actions/setup-dotnet@v5
-        with:
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5with:
           global-json-file: global.json
 
       - name: Install Versionize


### PR DESCRIPTION
## **User description**
Pins all third-party GitHub Actions to commit SHAs to satisfy OpenSSF Scorecard / CodeQL Pinned-Dependencies alert.

- Skips already-SHA-pinned actions
- Skips internal reusable workflows under `KooshaPari/phenoShared`, `phenotype-tooling`, `phenotypeActions`, `template-commons`
- Skips floating refs (`@master`, `@main`, `@stable`) — flagged for separate review
- Each pinned line preserves original tag in trailing comment for upgrade visibility

Generated via Contents API. Part of org-wide PinnedDependencies wave 1 (top-5 alert repos).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly mechanical CI hardening, but several workflow `uses:` lines appear malformed (e.g., merged `# vXwith:` comments and an invalid `setup-zig` ref), which could break CI runs.
> 
> **Overview**
> Pins many GitHub Actions in `.github/workflows/*` (checkout, language setup, artifact upload/download, SonarCloud, CodeQL, Codecov, gh-pages, etc.) from floating tags to **specific commit SHAs** for supply-chain hardening.
> 
> Reviewers should double-check workflow validity: some updated `uses:` entries appear to have **formatting/concatenation issues** (e.g. `# v5with:`) and `polyglot-build.yml` has an **invalid** `goto-bus-stop/setup-zig@…` ref that will fail unless corrected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d8703b901ebd9bd40bcfae0330797f5ae1c0e1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
Pin GitHub Actions used in workflows to specific commit SHAs

### What Changed
- Replaced floating Action versions with fixed commit SHAs across CI, release, testing, docs, and analysis workflows
- Kept the same workflow steps and outputs while reducing reliance on changing third-party Action releases
- Preserved version comments so updates are easier to review later

### Impact
`✅ Safer CI runs`
`✅ Fewer unexpected workflow changes`
`✅ Lower risk from third-party Action updates`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=uxvIAdcgHzsvVnkjL05jkmiIeujDuqeFLSWW_2LK7fQ&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
