### PR TITLE
Make Taskfile detect project language

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,31 +1,92 @@
 version: "3"
 
-vars:
-  SOLUTION: src/DINOForge.sln
-  CONFIG: Release
-
 tasks:
   default:
-    desc: Build the solution
+    desc: Build the detected project
     cmds:
       - task: build
 
   build:
-    desc: Build the .NET solution
+    desc: Build the detected project
     cmds:
-      - dotnet build {{.SOLUTION}} -c {{.CONFIG}}
+      - |
+        if ls *.sln >/dev/null 2>&1 || find . -name '*.csproj' -not -path './.git/*' | grep -q .; then
+          dotnet build
+        elif [ -f package.json ]; then
+          if command -v bun >/dev/null 2>&1 && [ -f bun.lockb -o -f bun.lock ]; then
+            bun run build
+          else
+            npm run build
+          fi
+        elif [ -f pyproject.toml ]; then
+          python -m build
+        elif [ -f go.mod ]; then
+          go build ./...
+        elif [ -f Cargo.toml ]; then
+          cargo build
+        else
+          echo "No build target detected."
+        fi
 
   test:
-    desc: Run the .NET test suite
+    desc: Run tests for the detected project
     cmds:
-      - dotnet test {{.SOLUTION}} -c {{.CONFIG}} --collect:"XPlat Code Coverage"
+      - |
+        if ls *.sln >/dev/null 2>&1 || find . -name '*.csproj' -not -path './.git/*' | grep -q .; then
+          dotnet test
+        elif [ -f package.json ]; then
+          if command -v bun >/dev/null 2>&1 && [ -f bun.lockb -o -f bun.lock ]; then
+            bun test
+          else
+            npm test
+          fi
+        elif [ -f pyproject.toml ]; then
+          pytest
+        elif [ -f go.mod ]; then
+          go test ./...
+        elif [ -f Cargo.toml ]; then
+          cargo test
+        else
+          echo "No test target detected."
+        fi
 
   lint:
-    desc: Run formatting and analyzer checks
+    desc: Run lint checks for the detected project
     cmds:
-      - dotnet format {{.SOLUTION}} --verify-no-changes
+      - |
+        if ls *.sln >/dev/null 2>&1 || find . -name '*.csproj' -not -path './.git/*' | grep -q .; then
+          dotnet format --verify-no-changes
+        elif [ -f package.json ]; then
+          if command -v bun >/dev/null 2>&1 && [ -f bun.lockb -o -f bun.lock ]; then
+            bun run lint
+          else
+            npm run lint
+          fi
+        elif [ -f pyproject.toml ]; then
+          ruff check .
+        elif [ -f go.mod ]; then
+          go vet ./...
+        elif [ -f Cargo.toml ]; then
+          cargo clippy --all-targets --all-features -- -D warnings
+        else
+          echo "No lint target detected."
+        fi
 
   clean:
     desc: Clean build outputs
     cmds:
-      - dotnet clean {{.SOLUTION}} -c {{.CONFIG}}
+      - |
+        if ls *.sln >/dev/null 2>&1 || find . -name '*.csproj' -not -path './.git/*' | grep -q .; then
+          dotnet clean
+        elif [ -f package.json ]; then
+          rm -rf dist build .next coverage
+        elif [ -f pyproject.toml ]; then
+          rm -rf build dist *.egg-info .pytest_cache .ruff_cache
+          find . -type d -name __pycache__ -prune -exec rm -rf {} +
+        elif [ -f go.mod ]; then
+          go clean
+        elif [ -f Cargo.toml ]; then
+          cargo clean
+        else
+          echo "No clean target detected."
+        fi


### PR DESCRIPTION
Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to local task runner commands, but could affect CI/dev workflows if project detection picks the wrong tool or expected args (e.g., missing coverage flags).
> 
> **Overview**
> Updates `Taskfile.yml` to **auto-detect the project type** and run the appropriate `build`, `test`, `lint`, and `clean` commands for .NET, Node (preferring `bun` when a bun lockfile exists), Python, Go, or Rust.
> 
> Removes the hardcoded `.sln`/`Release` vars and switches tasks from explicit `dotnet ... {{.SOLUTION}} -c {{.CONFIG}}` invocations to generic tool commands, with a fallback message when no target is detected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97d333f9df7c53bc54564f9b3ebb9181e17d7e35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->