### PR TITLE
Add Taskfile project detection

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,10 +6,39 @@ tasks:
     cmds:
       - task: build
 
+  detect:
+    desc: Detect the project language or build system
+    silent: true
+    cmds:
+      - |
+        if ls *.sln >/dev/null 2>&1 || find . -name '*.csproj' -not -path './.git/*' | grep -q .; then
+          echo dotnet
+        elif [ -f package.json ]; then
+          echo javascript
+        elif [ -f deno.json ] || [ -f deno.jsonc ]; then
+          echo deno
+        elif [ -f pyproject.toml ]; then
+          echo python
+        elif [ -f go.mod ]; then
+          echo go
+        elif [ -f Cargo.toml ]; then
+          echo rust
+        elif [ -f pom.xml ]; then
+          echo maven
+        elif [ -f gradlew ] || [ -f build.gradle ] || [ -f build.gradle.kts ]; then
+          echo gradle
+        elif [ -f Makefile ]; then
+          echo make
+        else
+          echo unknown
+        fi
+
   build:
     desc: Build the detected project
     cmds:
       - |
+        language="$(task detect)"
+        echo "Detected project type: ${language}"
         if ls *.sln >/dev/null 2>&1 || find . -name '*.csproj' -not -path './.git/*' | grep -q .; then
           dotnet build
         elif [ -f package.json ]; then
@@ -46,6 +75,8 @@ tasks:
     desc: Run tests for the detected project
     cmds:
       - |
+        language="$(task detect)"
+        echo "Detected project type: ${language}"
         if ls *.sln >/dev/null 2>&1 || find . -name '*.csproj' -not -path './.git/*' | grep -q .; then
           dotnet test
         elif [ -f package.json ]; then
@@ -82,6 +113,8 @@ tasks:
     desc: Run lint checks for the detected project
     cmds:
       - |
+        language="$(task detect)"
+        echo "Detected project type: ${language}"
         if ls *.sln >/dev/null 2>&1 || find . -name '*.csproj' -not -path './.git/*' | grep -q .; then
           dotnet format --verify-no-changes
         elif [ -f package.json ]; then
@@ -119,6 +152,8 @@ tasks:
     desc: Clean build outputs
     cmds:
       - |
+        language="$(task detect)"
+        echo "Detected project type: ${language}"
         if ls *.sln >/dev/null 2>&1 || find . -name '*.csproj' -not -path './.git/*' | grep -q .; then
           dotnet clean
         elif [ -f package.json ]; then


### PR DESCRIPTION
## **User description**
Co-authored-by: Codex <noreply@openai.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Taskfile build/test/lint/clean scripting and only add a non-failing detection/echo step before existing commands.
> 
> **Overview**
> Adds a new `detect` task to infer the project type (dotnet/js/deno/python/go/rust/maven/gradle/make/unknown) based on common repo files.
> 
> Updates `build`, `test`, `lint`, and `clean` to call `task detect` and print the detected project type before running the existing conditional command selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b1afee268a5ec8bf25d1ecd28eb743f524c2858. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Show the detected project type before running common Taskfile commands**

### What Changed
- Added a detection step that identifies the project as dotnet, JavaScript, Deno, Python, Go, Rust, Maven, Gradle, Make, or unknown
- Build, test, lint, and clean now print the detected project type before running their existing actions
- `lint` still falls back to a validity check and prints a clear message when no lint target is found

### Impact
`✅ Clearer build/test output`
`✅ Easier confirmation of the detected project type`
`✅ Fewer surprises when running shared Taskfile commands`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=5Ob6D14lAU15-odnW-0lWqUKWcf5CCyXzsDenbqAVJs&org=KooshaPari)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
