### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,42 @@
+# Build artifacts
+target/
+dist/
+build/
+*.o
+*.so
+*.dylib
+*.rlib
+*.rmeta
+
+# Dependencies
+node_modules/
+vendor/
+.venv/
+venv/
+.env
+.env.local
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+
+# Test
+coverage/
+*.lcov
+.nyc_output/
+
+# Misc
+*.tmp
+*.bak
+*.orig


### PR DESCRIPTION
Add standard .gitignore with build, IDE, OS, and test artifacts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds ignore rules only; no runtime code or behavior changes.
> 
> **Overview**
> Adds a new `.gitignore` to exclude common build outputs, dependency directories, environment files, IDE/OS artifacts, logs, test coverage outputs, and temporary/backup files from version control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bc70e34207464ed70ba349ab738a2b98d2e6bf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->