### PR TITLE
fix(gamelaunch): stabilize bootstrap after stash pack duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- GameLaunch bootstrap: pre-flight process cleanup, wait for mod platform + loaded packs; skip `*.disabled` pack folders on deploy/discovery and dedupe duplicate pack IDs (fixes empty `LoadedPacks` after stash integration).
 - Pre-push unit tests: stabilize GameClient connect/send timeouts under CI load, DumpTools subprocess build-once + kill-on-timeout, framing tests assert timeout values not wall clock.
 - Post-PR188 follow-up: GameLaunch attach-mode bridge restart, Sonar batch-4 exclusions, packages.lock.json refresh for CI.
 - `PackLoads` SDK model: add missing YAML load lists (`resources`, `economy_profiles`, etc.) so `ModPlatform` and `DeployToGame` builds succeed locally.

--- a/src/Runtime/DINOForge.Runtime.csproj
+++ b/src/Runtime/DINOForge.Runtime.csproj
@@ -276,7 +276,11 @@
   <!-- Deploy packs from repo to game directory -->
   <Target Name="DeployPacks" AfterTargets="Build" Condition="'$(DeployToGame)' == 'true' and Exists('$(BepInExDir)') and '$(TargetFramework)' == 'netstandard2.0'">
     <ItemGroup>
-      <PackFiles Include="$(MSBuildThisFileDirectory)..\..\packs\**\*" Exclude="$(MSBuildThisFileDirectory)..\..\packs\test-*;$(MSBuildThisFileDirectory)..\..\packs\test-*\**\*" />
+      <PackFiles Include="$(MSBuildThisFileDirectory)..\..\packs\**\*"
+                  Exclude="$(MSBuildThisFileDirectory)..\..\packs\test-*;
+                           $(MSBuildThisFileDirectory)..\..\packs\test-*\**\*;
+                           $(MSBuildThisFileDirectory)..\..\packs\**\*.disabled\**\*;
+                           $(MSBuildThisFileDirectory)..\..\packs\**\*.disabled" />
     </ItemGroup>
     <MakeDir Directories="$(BepInExDir)\dinoforge_packs" Condition="!Exists('$(BepInExDir)\dinoforge_packs')" />
     <Copy SourceFiles="@(PackFiles)"

--- a/src/SDK/ContentLoader.cs
+++ b/src/SDK/ContentLoader.cs
@@ -229,6 +229,7 @@ namespace DINOForge.SDK
                     : ContentLoadResult.Success(new List<string>().AsReadOnly());
             }
 
+            manifests = DeduplicateManifestsByPackId(manifests, errors);
             DependencyResult dependencyResult = _dependencyResolver.ComputeLoadOrder(manifests.Select(item => item.Manifest));
             if (!dependencyResult.IsSuccess)
             {
@@ -296,6 +297,52 @@ namespace DINOForge.SDK
             }
 
             return manifests;
+        }
+
+        /// <summary>
+        /// Collapses duplicate pack IDs (e.g. <c>economy-balanced</c> and <c>economy-balanced.disabled</c>)
+        /// before dependency resolution. Prefers directories whose folder name does not end with
+        /// <c>.disabled</c>.
+        /// </summary>
+        private static List<(string Directory, PackManifest Manifest)> DeduplicateManifestsByPackId(
+            List<(string Directory, PackManifest Manifest)> manifests,
+            List<string> errors)
+        {
+            Dictionary<string, (string Directory, PackManifest Manifest)> byId =
+                new Dictionary<string, (string Directory, PackManifest Manifest)>(StringComparer.OrdinalIgnoreCase);
+
+            foreach ((string directory, PackManifest manifest) in manifests)
+            {
+                if (!byId.TryGetValue(manifest.Id, out (string Directory, PackManifest Manifest) existing))
+                {
+                    byId[manifest.Id] = (directory, manifest);
+                    continue;
+                }
+
+                bool existingIsDisabled = Path.GetFileName(existing.Directory)
+                    .EndsWith(".disabled", StringComparison.OrdinalIgnoreCase);
+                bool candidateIsDisabled = Path.GetFileName(directory)
+                    .EndsWith(".disabled", StringComparison.OrdinalIgnoreCase);
+
+                if (existingIsDisabled && !candidateIsDisabled)
+                {
+                    errors.Add(
+                        $"Duplicate pack ID '{manifest.Id}' in {existing.Directory} — using {directory} instead.");
+                    byId[manifest.Id] = (directory, manifest);
+                }
+                else if (!existingIsDisabled && candidateIsDisabled)
+                {
+                    errors.Add(
+                        $"Duplicate pack ID '{manifest.Id}' in {directory} — pack will be skipped.");
+                }
+                else
+                {
+                    errors.Add(
+                        $"Duplicate pack ID '{manifest.Id}' in {directory} — pack will be skipped.");
+                }
+            }
+
+            return byId.Values.ToList();
         }
 
         private void LoadManifestContent(string packDirectory, PackManifest manifest, List<string> errors)

--- a/src/SDK/ContentLoader.cs
+++ b/src/SDK/ContentLoader.cs
@@ -330,11 +330,6 @@ namespace DINOForge.SDK
                         $"Duplicate pack ID '{manifest.Id}' in {existing.Directory} — using {directory} instead.");
                     byId[manifest.Id] = (directory, manifest);
                 }
-                else if (!existingIsDisabled && candidateIsDisabled)
-                {
-                    errors.Add(
-                        $"Duplicate pack ID '{manifest.Id}' in {directory} — pack will be skipped.");
-                }
                 else
                 {
                     errors.Add(

--- a/src/SDK/FileDiscoveryService.cs
+++ b/src/SDK/FileDiscoveryService.cs
@@ -152,6 +152,12 @@ namespace DINOForge.SDK
 
             foreach (var dir in allDirs)
             {
+                string dirName = Path.GetFileName(dir);
+                if (dirName.EndsWith(".disabled", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
                 string manifestPath = Path.Combine(dir, "pack.yaml");
                 if (File.Exists(manifestPath))
                 {

--- a/src/Tests/GameLaunch/GameLaunchFixture.cs
+++ b/src/Tests/GameLaunch/GameLaunchFixture.cs
@@ -34,13 +34,13 @@ namespace DINOForge.Tests.GameLaunch;
 /// </summary>
 public sealed class GameLaunchFixture : IAsyncLifetime
 {
-    private const string GameExecutableName = "Diplomacy is Not an Option.exe";
-    private const string GameProcessBaseName = "Diplomacy is Not an Option";
+    private const string GameExecutableName = GameLaunchProcessCleanup.GameProcessBaseName + ".exe";
 
     private const int DefaultBootstrapTimeoutMs = 90_000;
     private const int PollIntervalMs = 500;
     private const int PerAttemptConnectTimeoutMs = 10_000;
     private const int PerAttemptWorldWaitMs = 15_000;
+    private const int PerAttemptModPlatformWaitMs = 30_000;
 
     private Process? _gameProcess;
     private bool _launchedGame;
@@ -114,6 +114,9 @@ public sealed class GameLaunchFixture : IAsyncLifetime
                 return;
             }
 
+            // Game Launch Protocol: avoid attaching to a zombie instance without a healthy bridge.
+            GameLaunchProcessCleanup.StopStrayGameProcesses();
+
             _gameProcess = Process.Start(new ProcessStartInfo
             {
                 FileName = gameExePath,
@@ -156,7 +159,7 @@ public sealed class GameLaunchFixture : IAsyncLifetime
                 WaitResult worldResult = await Client
                     .WaitForWorldAsync(worldWaitMs, worldCts.Token)
                     .ConfigureAwait(true);
-                if (worldResult.Ready)
+                if (worldResult.Ready && await WaitForModPlatformReadyAsync(deadline).ConfigureAwait(true))
                 {
                     IsInitialized = true;
                     return;
@@ -224,12 +227,61 @@ public sealed class GameLaunchFixture : IAsyncLifetime
     {
         try
         {
-            return Process.GetProcessesByName(GameProcessBaseName).Length > 0;
+            return Process.GetProcessesByName(GameLaunchProcessCleanup.GameProcessBaseName).Length > 0;
         }
         catch
         {
             return false;
         }
+    }
+
+    private async Task<bool> WaitForModPlatformReadyAsync(DateTime deadline)
+    {
+        if (Client is null)
+        {
+            return false;
+        }
+
+        while (DateTime.UtcNow < deadline)
+        {
+            int remainingMs = (int)RemainingMs(deadline);
+            if (remainingMs <= 0)
+            {
+                break;
+            }
+
+            try
+            {
+                using CancellationTokenSource statusCts = new(
+                    TimeSpan.FromMilliseconds(Math.Min(PerAttemptModPlatformWaitMs, remainingMs)));
+                GameStatus status = await Client.StatusAsync(statusCts.Token).ConfigureAwait(true);
+                if (status.ModPlatformReady && status.LoadedPacks.Count > 0)
+                {
+                    return true;
+                }
+            }
+            catch
+            {
+                // Platform still bootstrapping — keep polling until bootstrap deadline.
+            }
+
+            int delayMs = (int)Math.Min(PollIntervalMs, RemainingMs(deadline));
+            if (delayMs <= 0)
+            {
+                break;
+            }
+
+            try
+            {
+                await Task.Delay(delayMs).ConfigureAwait(false);
+            }
+            catch
+            {
+                break;
+            }
+        }
+
+        return false;
     }
 
     private static long RemainingMs(DateTime deadline) =>
@@ -241,6 +293,8 @@ public sealed class GameLaunchFixture : IAsyncLifetime
         {
             try { _gameProcess?.Kill(entireProcessTree: true); }
             catch { /* best-effort */ }
+
+            GameLaunchProcessCleanup.StopStrayGameProcesses();
         }
 
         _gameProcess?.Dispose();

--- a/src/Tests/GameLaunch/GameLaunchProcessCleanup.cs
+++ b/src/Tests/GameLaunch/GameLaunchProcessCleanup.cs
@@ -1,0 +1,63 @@
+#nullable enable
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace DINOForge.Tests.GameLaunch;
+
+/// <summary>
+/// Pre/post-flight process cleanup for GameLaunch tests (SPEC-007 / Game Launch Protocol).
+/// Mirrors <c>Stop-StrayGameLaunchProcesses</c> in <c>scripts/game/prove-features-gate.ps1</c>.
+/// </summary>
+internal static class GameLaunchProcessCleanup
+{
+    internal const string GameProcessBaseName = "Diplomacy is Not an Option";
+    private static readonly string[] ProcessNamesToStop =
+    {
+        GameProcessBaseName,
+        "UnityCrashHandler64",
+    };
+
+    private const int PostKillVerifyDelayMs = 3_000;
+
+    /// <summary>
+    /// Stops stray game-related processes and waits briefly for exit (best-effort).
+    /// </summary>
+    public static void StopStrayGameProcesses()
+    {
+        foreach (string processName in ProcessNamesToStop)
+        {
+            TryKillProcessesByName(processName);
+        }
+
+        Thread.Sleep(PostKillVerifyDelayMs);
+    }
+
+    private static void TryKillProcessesByName(string processName)
+    {
+        try
+        {
+            foreach (Process process in Process.GetProcessesByName(processName))
+            {
+                using (process)
+                {
+                    try
+                    {
+                        if (!process.HasExited)
+                        {
+                            process.Kill(entireProcessTree: true);
+                        }
+                    }
+                    catch
+                    {
+                        // Best-effort — another test runner or the OS may own the process.
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // GetProcessesByName can throw on some hosts; cleanup remains best-effort.
+        }
+    }
+}


### PR DESCRIPTION
## **User description**
## Summary
- Add Game Launch Protocol pre-flight cleanup in `GameLaunchFixture` (kill stray DINO/UnityCrashHandler processes before launch, post-flight after teardown).
- Wait for `ModPlatformReady` and non-empty `LoadedPacks` before marking the fixture initialized.
- Fix pack load failure from duplicate `economy-balanced` / `vanilla-dino` manifests (`*.disabled` folders): skip during discovery, dedupe in `ContentLoader`, exclude from `DeployPacks`.

## Test plan
- [x] Deploy runtime with `DeployToGame=true` + `TargetFramework=netstandard2.0`
- [x] Local GameLaunch: **26/28 passed** (2 known flakes: asset-swap entity query, stat reload)
- [ ] CI build + CodeRabbit

## Notes
After PR #226 integration, deployed `packs/*.disabled/` copies caused `PackDependencyResolver` to throw on duplicate pack IDs, leaving `LoadedPacks` empty and all GameLaunch tests skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core pack discovery/load ordering and GameLaunch fixture gating; low security impact but can alter which pack wins on duplicate IDs in dev/deploy layouts.
> 
> **Overview**
> Fixes GameLaunch tests and pack loading when **`*.disabled`** stash copies sit beside active packs with the same pack ID, which previously broke dependency resolution and left **`LoadedPacks`** empty.
> 
> **Pack pipeline:** Discovery skips folders ending in `.disabled`, **`DeployPacks`** no longer copies them, and **`ContentLoader`** dedupes manifests by pack ID (preferring the non-`.disabled` directory and recording errors for skipped duplicates).
> 
> **GameLaunch bootstrap:** New **`GameLaunchProcessCleanup`** (aligned with `prove-features-gate.ps1`) kills stray DINO / Unity crash-handler processes before launch and after teardown. Initialization now requires world readiness **and** bridge **`ModPlatformReady`** with at least one loaded pack before tests run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3496bda34942d883f6d066cb84ee8c4f23455973. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Stabilize GameLaunch startup after duplicate pack copies**

### What Changed
- GameLaunch now clears stray game and crash-handler processes before starting, and cleans them up again after tests finish.
- GameLaunch waits for both mod platform readiness and at least one loaded pack before marking startup successful, so tests no longer begin against a half-ready game.
- Pack discovery and deployment now ignore `*.disabled` pack folders, and duplicate pack IDs are resolved by keeping the active copy and skipping the disabled one.

### Impact
`✅ Fewer GameLaunch startup failures`
`✅ Fewer skipped mod tests after pack duplication`
`✅ Cleaner pack loading after stash/disabled copies`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
