### PR TITLE
fix(gamelaunch): HUD bootstrap wait and fail gate on all-skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - GameLaunch bootstrap: pre-flight process cleanup, wait for mod platform + loaded packs; skip `*.disabled` pack folders on deploy/discovery and dedupe duplicate pack IDs (fixes empty `LoadedPacks` after stash integration).
+- `prove-features-gate.ps1`: fail full game gate when all GameLaunch tests skip (xUnit exit 0 on all-skipped).
+- GameLaunch HUD bootstrap test: wait for `CountLabel` with `exists` (HudStrip is alpha-hidden until hover).
 - Pre-push unit tests: stabilize GameClient connect/send timeouts under CI load, DumpTools subprocess build-once + kill-on-timeout, framing tests assert timeout values not wall clock.
 - Post-PR188 follow-up: GameLaunch attach-mode bridge restart, Sonar batch-4 exclusions, packages.lock.json refresh for CI.
 - `PackLoads` SDK model: add missing YAML load lists (`resources`, `economy_profiles`, etc.) so `ModPlatform` and `DeployToGame` builds succeed locally.

--- a/scripts/game/prove-features-gate.ps1
+++ b/scripts/game/prove-features-gate.ps1
@@ -89,6 +89,24 @@ function Stop-StrayGameLaunchProcesses {
     }
 }
 
+function Test-GameLaunchAllSkipped([string]$TestOutput) {
+    if ([string]::IsNullOrWhiteSpace($TestOutput)) {
+        return $false
+    }
+    if ($TestOutput -notmatch 'Skipped:\s+(\d+),\s+Total:\s+(\d+)') {
+        return $false
+    }
+    $skipped = [int]$Matches[1]
+    $total = [int]$Matches[2]
+    if ($total -le 0 -or $skipped -ne $total) {
+        return $false
+    }
+    if ($TestOutput -match 'Passed:\s+(\d+)') {
+        return [int]$Matches[1] -eq 0
+    }
+    return $true
+}
+
 function Resolve-DinoGameExePath {
     $path = $env:DINO_GAME_PATH
     if ([string]::IsNullOrWhiteSpace($path)) {
@@ -278,13 +296,18 @@ function Invoke-FullGate {
         }
 
         $gameExit = 0
+        $gameTestOutput = ''
         try {
             Write-Gate 'Running GameLaunch E2E tests (DINO_GAME_PATH detected)'
-            dotnet test 'src/Tests/GameLaunch/DINOForge.Tests.GameLaunch.csproj' `
+            $gameTestOutput = dotnet test 'src/Tests/GameLaunch/DINOForge.Tests.GameLaunch.csproj' `
                 -c Release `
                 --filter 'Category=GameLaunch' `
-                --verbosity minimal
+                --verbosity minimal 2>&1 | Out-String
             $gameExit = $LASTEXITCODE
+            if ($gameExit -eq 0 -and (Test-GameLaunchAllSkipped $gameTestOutput)) {
+                Write-Gate 'GameLaunch tests all skipped (fixture not initialized) — treating as failure' 'Error'
+                $gameExit = 1
+            }
         }
         finally {
             if (-not (Test-GameAttachOnlyMode)) {

--- a/scripts/game/prove-features-gate.ps1
+++ b/scripts/game/prove-features-gate.ps1
@@ -304,6 +304,9 @@ function Invoke-FullGate {
                 --filter 'Category=GameLaunch' `
                 --verbosity minimal 2>&1 | Out-String
             $gameExit = $LASTEXITCODE
+            if ($gameTestOutput) {
+                Write-Host $gameTestOutput
+            }
             if ($gameExit -eq 0 -and (Test-GameLaunchAllSkipped $gameTestOutput)) {
                 Write-Gate 'GameLaunch tests all skipped (fixture not initialized) — treating as failure' 'Error'
                 $gameExit = 1

--- a/src/Tests/GameLaunch/GameLaunchPackTests.cs
+++ b/src/Tests/GameLaunch/GameLaunchPackTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using DINOForge.Bridge.Protocol;
 using DINOForge.SDK;
 using DINOForge.SDK.Registry;
+using DINOForge.Tests.Support;
 using FluentAssertions;
 using Xunit;
 
@@ -37,16 +38,20 @@ public sealed class GameLaunchPackTests(GameLaunchFixture fixture)
         LoadSceneResult sceneResult = await fixture.Client.LoadSceneAsync(GameLaunchSceneNames.MainMenuBuildIndex);
         if (sceneResult.Success)
         {
-            await Task.Delay(3000);
+            bool dfCanvasReady = await TestWait.UntilAsync(
+                async () =>
+                {
+                    UiWaitResult wait = await fixture.Client.WaitForUiAsync(
+                        "name=CountLabel",
+                        "exists",
+                        timeoutMs: 2000).ConfigureAwait(false);
+                    return wait.Ready;
+                },
+                TimeSpan.FromSeconds(15),
+                pollMs: 250).ConfigureAwait(false);
+            dfCanvasReady.Should().BeTrue(
+                "HudStrip CountLabel should exist on DFCanvas after main menu load (DFCanvas may lag mod platform)");
         }
-
-        // DFCanvas/HudStrip may finish building after mod platform reports ready (alpha=0 strip is "exists" not "visible").
-        UiWaitResult hudReady = await fixture.Client.WaitForUiAsync(
-            "name=CountLabel",
-            "exists",
-            timeoutMs: 15_000);
-        hudReady.Ready.Should().BeTrue(
-            "HudStrip CountLabel should exist on DFCanvas after bootstrap (DFCanvas may lag mod platform)");
 
         UiActionResult hudLabel = await fixture.Client.QueryUiAsync("name=CountLabel");
         hudLabel.Success.Should().BeTrue("HudStrip CountLabel should be queryable after waitForUi");

--- a/src/Tests/GameLaunch/GameLaunchPackTests.cs
+++ b/src/Tests/GameLaunch/GameLaunchPackTests.cs
@@ -33,8 +33,23 @@ public sealed class GameLaunchPackTests(GameLaunchFixture fixture)
         status.LoadedPacks.Should().NotBeEmpty(
             "status JSON should list pack IDs from ModPlatform._lastLoadResult.LoadedPacks");
 
+        // Ensure main menu + DFCanvas are active (cold start can report packs before UGUI is built).
+        LoadSceneResult sceneResult = await fixture.Client.LoadSceneAsync(GameLaunchSceneNames.MainMenuBuildIndex);
+        if (sceneResult.Success)
+        {
+            await Task.Delay(3000);
+        }
+
+        // DFCanvas/HudStrip may finish building after mod platform reports ready (alpha=0 strip is "exists" not "visible").
+        UiWaitResult hudReady = await fixture.Client.WaitForUiAsync(
+            "name=CountLabel",
+            "exists",
+            timeoutMs: 15_000);
+        hudReady.Ready.Should().BeTrue(
+            "HudStrip CountLabel should exist on DFCanvas after bootstrap (DFCanvas may lag mod platform)");
+
         UiActionResult hudLabel = await fixture.Client.QueryUiAsync("name=CountLabel");
-        hudLabel.Success.Should().BeTrue("HudStrip CountLabel should exist on DFCanvas after bootstrap");
+        hudLabel.Success.Should().BeTrue("HudStrip CountLabel should be queryable after waitForUi");
         hudLabel.MatchedNode.Should().NotBeNull();
         hudLabel.MatchedNode!.Label.Should().NotBe("0 packs",
             "HUD strip label should reflect OnHudCountsChanged, not the Build() placeholder");


### PR DESCRIPTION
## **User description**
## Summary
- GameLaunch pack bootstrap test loads main menu and waits for HudStrip CountLabel (exists) before asserting HUD pack count text.
- prove-features-gate full mode treats all-skipped GameLaunch runs as failure (xUnit exits 0 when fixture never initializes).

## Test plan
- [x] Local: Bootstrap_LoadedPackCount passes with DINO_GAME_PATH
- [ ] CI Governance + Real Game Launch


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GameLaunch E2E tests and the feature gate script; no production game or auth paths are modified.
> 
> **Overview**
> Fixes **false-green GameLaunch CI** when the live fixture never starts and when HUD assertions run before UGUI is ready.
> 
> **`prove-features-gate.ps1`** now captures GameLaunch `dotnet test` output and, in full game mode, treats **all-skipped** runs (xUnit exit 0) as a **gate failure** via new **`Test-GameLaunchAllSkipped`**.
> 
> **`Bootstrap_LoadedPackCount_IsGreaterThanZero_ViaStatusAndHud`** loads the main menu scene and **polls `WaitForUi` for `CountLabel` with `exists`** (HudStrip can lag behind mod-platform status) before asserting the HUD pack count text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bddd1d2a14494fdfba1b3a211a69c9c731d66fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Stop GameLaunch from passing when every test is skipped**

### What Changed
- GameLaunch HUD bootstrap tests now wait for the HUD count label to exist after the main menu loads, so they no longer fail when the HUD appears after the mod platform is ready.
- The full GameLaunch gate now treats an all-skipped xUnit run as a failure instead of reporting success.
- The changelog now calls out both fixes.

### Impact
`✅ Fewer false-green GameLaunch runs`
`✅ More reliable HUD bootstrap checks`
`✅ Clearer CI failure when GameLaunch tests never start`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Game Gate validation now correctly fails when all GameLaunch tests skip, preventing false passes.
* HUD bootstrap test now properly waits for UI elements to load before validation checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KooshaPari/Dino/pull/228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->