### PR TITLE
hygiene(Dino): preserve journeys scaffold

### DIFF
--- a/docs/journeys/traceability.md
+++ b/docs/journeys/traceability.md
@@ -1,0 +1,80 @@
+# Journey Traceability
+
+Implements the [phenotype-infra journey-traceability standard](https://github.com/kooshapari/phenotype-infra/blob/main/docs/governance/journey-traceability-standard.md) for the DINOForge mod platform workspace.
+
+> **Note:** This file lives at `docs/journeys/traceability.md` (next to `manifests/`) to avoid clobber churn with tooling that targets `docs/operations/journey-traceability.md`.
+
+## Traceability Model
+
+Every developer-facing or operator-facing flow in DINOForge should be traceable across:
+
+1. **FR/NFR** — requirement ID and user story.
+2. **Spec** — acceptance criteria and non-regression constraints (including the .NET 11 preview / BepInEx Mono CLR constraints in `CLAUDE.md`).
+3. **Docs** — operator/user documentation and rich media placeholders.
+4. **Code** — CLI tool, SDK, plugin, content loader, validator, or pack surface implementing the flow.
+5. **Tests/Gates** — unit, integration, BDD, lint, and journey verification acting as autograders.
+6. **Evidence** — journey manifest, recording/keyframes, and evaluation verdict.
+
+## Developer-Facing and Operator-Facing Flows
+
+| Flow | Requirement | Implementation surface | Autograder gates | Evidence status |
+| --- | --- | --- | --- | --- |
+| Operator runs `task` build and verifies deterministic task DAG | FR-DINO-BUILD-001, NFR-DINO-REPRODUCIBILITY-001 | `Taskfile.yml`, build helper | task fixture tests, dry-run checks, BDD journey, eval verdict | Stubbed |
+| Mod author validates a domain plugin against SDK schemas | FR-DINO-SDK-001, NFR-DINO-CONTRACT-001 | SDK validators, registries, `ContentLoader` | schema negative tests, fixture manifests, journey manifest | Stubbed |
+| Mod author compiles a pack via PackCompiler | FR-DINO-PACK-001, NFR-DINO-CONTRACT-001 | `PackCompiler` (net11.0), pack schema | pack fixture tests, roundtrip tests, eval verdict | Stubbed |
+| Mod author exercises runtime/plugin bridge end-to-end | FR-DINO-RUNTIME-001, NFR-DINO-STABILITY-001 | `DINOForge.Runtime` (netstandard2.0), BepInEx plugin | runtime fixture tests, plugin isolation tests, BDD journey | Stubbed |
+| Operator queries/invokes platform tools via MCP server | FR-DINO-MCP-001, NFR-DINO-OPERABILITY-001 | `McpServer` (net11.0), tool surface | MCP contract tests, tool smoke tests, journey manifest | Stubbed |
+
+## Rich Media Stubs
+
+<!-- RICH-MEDIA-STUB type="animated-gif" subject="Task DAG build and dry-run" journey="dino-task-build-dry-run" status="TODO" -->
+![DINOForge task build — task list, dry-run graph, build output, and evidence log](../assets/rich-media/dino/task-build-dry-run.gif)
+
+*Expected capture: run `task --list`, perform a deterministic task dry-run, execute a fixture build, and capture evidence links for the build DAG.*
+
+<!-- RICH-MEDIA-STUB type="annotated-screenshot" subject="Domain plugin schema validation" journey="dino-domain-plugin-validation" status="TODO" -->
+![DINOForge plugin validation — fixture manifest, validator output, error report, and SDK link](../assets/rich-media/dino/domain-plugin-validation.png)
+
+*Expected capture: validate a deterministic plugin manifest, show valid/invalid cases, and link each report back to the SDK validator used.*
+
+<!-- RICH-MEDIA-STUB type="journey-eval" subject="Pack compile roundtrip verdict" journey="dino-pack-compile-roundtrip" status="TODO" -->
+![DINOForge pack compile — input pack, compiled output, roundtrip diff, and eval verdict](../assets/rich-media/dino/pack-compile-roundtrip.png)
+
+*Expected capture: run PackCompiler against a fixture pack, roundtrip the output, and attach a pass/fail verdict for FR-DINO-PACK-001 and NFR-DINO-CONTRACT-001.*
+
+<!-- RICH-MEDIA-STUB type="journey-eval" subject="Runtime plugin bridge verdict" journey="dino-runtime-plugin-bridge" status="TODO" -->
+![DINOForge runtime — plugin loaded, BepInEx lifecycle, bridge call, and eval verdict](../assets/rich-media/dino/runtime-plugin-bridge.png)
+
+*Expected capture: load a fixture plugin into the runtime, exercise a bridge call, and attach a pass/fail verdict honoring the netstandard2.0-only runtime constraint.*
+
+## Journey Manifests
+
+Journey manifests should live in `docs/journeys/manifests/` and include:
+
+- FR/NFR IDs covered by the journey;
+- CLI command, `task` target, `PackCompiler` invocation, or MCP tool used to reproduce the flow;
+- deterministic fixture pack/manifest/bridge payload required for replay;
+- expected screenshots/GIFs/keyframes;
+- tests and gates that must pass before the journey is accepted;
+- eval verdict schema and pass/fail criteria.
+
+## Autograder Gates
+
+Minimum gates before marking a journey complete:
+
+- `task` fixture tests for build/dry-run flows;
+- SDK schema negative and drift tests for plugin validation;
+- PackCompiler roundtrip and contract tests;
+- runtime isolation tests honoring the netstandard2.0-only BepInEx constraint;
+- MCP contract tests for the platform tool surface;
+- doc link validation for every referenced rich media asset;
+- journey manifest validation via `phenotype-journey verify` when available;
+- eval verdict linked to the FR/NFR IDs in the manifest.
+
+## Status
+
+- [x] Identify initial build, SDK, pack, runtime, and MCP flows
+- [x] Stub rich media embeds for expected screenshots/GIFs/evals
+- [ ] Author manifests in `docs/journeys/manifests/`
+- [ ] Record journey captures for each flow
+- [ ] Run `phenotype-journey verify` in CI


### PR DESCRIPTION
## **User description**
Preserves the 2026-06-05 local journey traceability scaffold commit (831ee0c). Preservation-only; do not merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime, auth, or build logic changes; only affects journey docs and future evidence workflows.
> 
> **Overview**
> Adds **`docs/journeys/traceability.md`** to preserve the local journey traceability scaffold and align DINOForge with the phenotype-infra journey-traceability standard. The doc deliberately sits next to `manifests/` rather than under `docs/operations/` to avoid tooling clobber.
> 
> It defines a six-layer traceability model (FR/NFR → spec → docs → code → tests/gates → evidence) and maps five initial flows—**`task` build/dry-run**, **SDK plugin validation**, **PackCompiler**, **runtime/BepInEx bridge**, and **MCP tools**—to requirement IDs, implementation surfaces, and autograder gates, all marked **Stubbed** for evidence.
> 
> The change also introduces **rich-media stub** embeds (GIF/screenshots under `../assets/rich-media/dino/`), expectations for future **`docs/journeys/manifests/`** content, minimum autograder gates (including `phenotype-journey verify`), and a checklist where flow identification and media stubs are done but manifests, captures, and CI verify remain open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 831ee0c4cfeaa18f337c6ee910a51d82c1afdccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add a journey traceability scaffold for DINOForge**

### What Changed
- Adds a journey traceability document that links key DINOForge flows to requirements, docs, code, tests, and evidence
- Covers the main user-facing flows: build and dry-run, plugin validation, pack compilation, runtime bridge checks, and MCP tool use
- Adds placeholders for expected screenshots, GIFs, journey manifests, and acceptance gates for future verification

### Impact
`✅ Clearer journey documentation`
`✅ Easier evidence collection for key flows`
`✅ More consistent release verification`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
