### PR TITLE
chore(workflows): hygiene pass

### DIFF
--- a/.github/workflows/agent-merge-on-bot-approve.yml
+++ b/.github/workflows/agent-merge-on-bot-approve.yml
@@ -12,9 +12,6 @@ on:
         description: PR number to merge (e.g. 221)
         required: true
         type: number
-
-permissions:
-  contents: write
   pull-requests: write
   checks: read
 
@@ -100,3 +97,10 @@ jobs:
             } catch (err) {
               core.setFailed(`Merge failed: ${err.message}`);
             }
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -1,4 +1,11 @@
 name: API Reference
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
@@ -8,15 +15,11 @@ on:
       - 'src/Bridge/Client/**'
       - 'docfx.json'
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   build-api-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
         with:
           dotnet-version: '11.0.x'
@@ -25,7 +28,7 @@ jobs:
       - name: Generate API metadata
         run: docfx metadata docfx.json
       - name: Upload API docs artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: api-docs
           path: docs/api/

--- a/.github/workflows/asset-pipeline.yml
+++ b/.github/workflows/asset-pipeline.yml
@@ -1,4 +1,11 @@
 name: Asset Pipeline Build
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
@@ -9,10 +16,6 @@ on:
       - '.github/workflows/asset-pipeline.yml'
   pull_request:
     branches: [main]
-
-permissions:
-  contents: read
-
 jobs:
   build:
     name: Build & Test Asset Pipeline
@@ -20,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup .NET 8.0
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
@@ -58,7 +61,7 @@ jobs:
 
       - name: Upload pipeline artifacts
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: asset-pipeline-output
           path: packs/warfare-starwars/output/
@@ -74,10 +77,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@0355742c943ddb13ca8a6b700f824231caa91e75 # v-latest
         with:
           node-version: 22
 
@@ -101,5 +104,5 @@ jobs:
         if: steps.check-vitepress.outputs.has-package-json == 'true'
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ github.token }}
           publish_dir: docs/.vitepress/dist

--- a/.github/workflows/benchmark-regression-gate.yml
+++ b/.github/workflows/benchmark-regression-gate.yml
@@ -9,10 +9,6 @@ on:
       - 'src/Tools/PackCompiler/**'
       - 'src/Tests/Benchmarks/**'
       - '.github/workflows/benchmark-regression-gate.yml'
-
-permissions:
-  pull-requests: write
-
 jobs:
   benchmark-regression:
     runs-on: ubuntu-latest
@@ -21,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup .NET
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3  # v4.0.0
@@ -54,7 +50,7 @@ jobs:
           echo "Found CSV: $CSV_PATH"
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: '3.11'
 
@@ -83,7 +79,7 @@ jobs:
 
       - name: Comment PR on regression
         if: steps.report.outputs.status == 'FAIL'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v-latest
         with:
           script: |
             const fs = require('fs');
@@ -114,8 +110,15 @@ jobs:
 
       - name: Upload benchmark report
         if: always()
-        uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a  # v4.3.6
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: benchmark-report
           path: benchmark_report.json
           retention-days: 30
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,11 +1,14 @@
 name: Performance Benchmarks
-
-on:
-  workflow_dispatch:
-
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
+on:
+  workflow_dispatch:
 jobs:
   benchmark:
     name: BenchmarkDotNet
@@ -13,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup .NET
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
@@ -110,7 +113,7 @@ jobs:
           echo '{"timestamp": "'$(date -u +%Y-%m-%dT%H:%M:%SZ)'", "status": "completed"}' > docs/benchmarks/latest.json
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         if: always()
         with:
           name: benchmark-results

--- a/.github/workflows/build-gate.yml
+++ b/.github/workflows/build-gate.yml
@@ -25,7 +25,7 @@ jobs:
   build-sdk:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
         with:
           dotnet-version: '11.0.x'
@@ -47,7 +47,7 @@ jobs:
   build-runtime:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
         with:
           dotnet-version: '11.0.x'
@@ -69,7 +69,7 @@ jobs:
   build-runtime-windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
         with:
           dotnet-version: '11.0.x'
@@ -91,7 +91,7 @@ jobs:
   build-cli:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
         with:
           dotnet-version: '11.0.x'
@@ -113,7 +113,7 @@ jobs:
   build-packcompiler:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       - uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
         with:
           dotnet-version: '11.0.x'

--- a/.github/workflows/changelog-lint.yml
+++ b/.github/workflows/changelog-lint.yml
@@ -1,4 +1,11 @@
 name: changelog-lint
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 # Pattern #92 ledger-discipline gate — fails CI when CHANGELOG.md regresses
 # into duplicate version headers, missing tag rows, non-Keep-a-Changelog
@@ -26,10 +33,6 @@ on:
       - "docs/qa/closed-tasks.txt"
       - ".github/workflows/changelog-lint.yml"
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   changelog-lint-check:
     name: Pattern #92 ledger-discipline
@@ -37,13 +40,13 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
         with:
           # fetch all tags so the tag-coverage parity check has the full set
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: "3.12"
 
@@ -55,7 +58,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: changelog-lint-report
           path: docs/qa/changelog-lint-report.json

--- a/.github/workflows/ci-status-badges.yml
+++ b/.github/workflows/ci-status-badges.yml
@@ -10,9 +10,6 @@ on:
       - '.github/workflows/*.yml'
       - 'scripts/ci/generate-badges.py'
   workflow_dispatch:
-
-permissions:
-  contents: write
   actions: read
 
 jobs:
@@ -21,17 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: '3.12'
 
       - name: Generate badges
         run: python scripts/ci/generate-badges.py --repo ${{ github.repository }} --workflows ci,build-gate,lint,test-isolation,polyglot-build
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Commit badge updates
         if: github.ref == 'refs/heads/main'
@@ -41,3 +38,10 @@ jobs:
           git add README.md || true
           git diff --staged --quiet || git commit -m "ci: update CI status badges [skip ci]"
           git push || true
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup .NET
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
@@ -167,7 +167,7 @@ jobs:
           pwsh -ExecutionPolicy Bypass -File scripts/game/prove-features-gate.ps1 -ValidateOnly
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: '3.10'
           cache: 'pip'
@@ -238,7 +238,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup .NET
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
@@ -273,7 +273,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
         with:
           fetch-depth: 0  # SonarCloud needs full history for blame analysis
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,10 @@ permissions:
   actions: read
   contents: read
   security-events: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   analyze:
@@ -22,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup .NET
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0

--- a/.github/workflows/configureawait.yml
+++ b/.github/workflows/configureawait.yml
@@ -1,4 +1,11 @@
 name: configureawait
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 # Pattern #98 detection gate — fails CI when a C# library await is
 # missing the ``.ConfigureAwait(false)`` suffix. Library code that
@@ -30,10 +37,6 @@ on:
       - "docs/qa/configureawait-allowlist.txt"
       - ".github/workflows/configureawait.yml"
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   configureawait-check:
     name: Pattern #98 missing-configureawait
@@ -41,10 +44,10 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: "3.12"
 
@@ -56,7 +59,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: configureawait-report
           path: docs/qa/configureawait-report.json

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -5,10 +5,6 @@ on:
     # Run daily at 00:00 UTC
     - cron: '0 0 * * *'
   workflow_dispatch:
-
-permissions:
-  contents: write
-
 jobs:
   update-dashboard:
     runs-on: ubuntu-latest
@@ -49,3 +45,10 @@ jobs:
         if: steps.check.outputs.changed == 'false'
         run: |
           echo "Dashboard is up to date, no changes to commit."
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@0355742c943ddb13ca8a6b700f824231caa91e75 # v-latest
         with:
           node-version: 20
 
@@ -45,7 +45,7 @@ jobs:
           GITHUB_PAGES: "true"
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
+        uses: actions/upload-pages-artifact@98ef48e41587a300b82de4cf298aa98b57b2faae # v-latest
         with:
           path: docs/.vitepress/dist
 
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v-latest

--- a/.github/workflows/direct-datetime.yml
+++ b/.github/workflows/direct-datetime.yml
@@ -1,4 +1,11 @@
 name: direct-datetime
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 # Pattern #100 detection gate — fails CI when production C# code uses
 # ``DateTime.UtcNow`` / ``DateTime.Now`` directly instead of going
@@ -29,10 +36,6 @@ on:
       - "docs/qa/direct-datetime-allowlist.txt"
       - ".github/workflows/direct-datetime.yml"
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   direct-datetime-check:
     name: Pattern #100 direct-datetime
@@ -40,10 +43,10 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: "3.12"
 
@@ -55,7 +58,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: direct-datetime-report
           path: docs/qa/direct-datetime-report.json

--- a/.github/workflows/framework-version.yml
+++ b/.github/workflows/framework-version.yml
@@ -1,4 +1,11 @@
 name: framework-version
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 # Pattern #94 detection gate — fails CI when a pack manifest declares an
 # unbounded ``framework_version`` constraint (no ``<`` upper bound) or a
@@ -29,10 +36,6 @@ on:
       - "docs/qa/framework-version-allowlist.txt"
       - ".github/workflows/framework-version.yml"
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   framework-version-check:
     name: Pattern #94 framework_version
@@ -40,10 +43,10 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: "3.12"
 
@@ -58,7 +61,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: framework-version-report
           path: docs/qa/framework-version-report.json

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,19 +1,22 @@
 name: Nightly Fuzz
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   schedule:
     - cron: '0 2 * * *'  # 2am UTC nightly
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   property-tests:
     name: FsCheck Property Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
         with:
@@ -52,7 +55,7 @@ jobs:
 
       - name: Upload property test results
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: property-test-results
           path: TestResults/Property/
@@ -61,7 +64,7 @@ jobs:
     name: Fuzz Target Smoke Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
         with:
@@ -100,7 +103,7 @@ jobs:
 
       - name: Upload fuzz smoke test results
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: fuzz-smoke-results
           path: TestResults/FuzzSmoke/
@@ -109,7 +112,7 @@ jobs:
     name: Validate Fuzz Corpus Files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Check corpus files exist
         run: |

--- a/.github/workflows/game-automation.yml
+++ b/.github/workflows/game-automation.yml
@@ -25,9 +25,6 @@ on:
         description: 'Test duration in seconds'
         required: false
         default: '60'
-
-permissions:
-  contents: read
   checks: write
 
 jobs:
@@ -43,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
         with:
           fetch-depth: 0
 
@@ -158,7 +155,7 @@ jobs:
 
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: game-automation-screenshots-${{ matrix.instances }}-instances
           path: docs/automation/screenshots/
@@ -167,7 +164,7 @@ jobs:
 
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: game-automation-logs-${{ matrix.instances }}-instances
           path: |
@@ -213,3 +210,10 @@ jobs:
       - name: Set job status
         if: needs.parallel-automation.result == 'failure'
         run: exit 1
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+

--- a/.github/workflows/game-launch-validation.yml
+++ b/.github/workflows/game-launch-validation.yml
@@ -1,4 +1,11 @@
 name: Real Game Launch Validation
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   pull_request:
@@ -6,10 +13,6 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   game-launch-validation:
     name: Real Game Launch Validation
@@ -23,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup .NET 11
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
@@ -98,7 +101,7 @@ jobs:
 
       - name: Upload failure artifacts
         if: failure() && github.event_name != 'pull_request'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: game-launch-failures
           path: |
@@ -110,7 +113,7 @@ jobs:
 
       - name: Comment on PR with failure analysis
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v-latest
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/game-launch.yml
+++ b/.github/workflows/game-launch.yml
@@ -5,6 +5,13 @@ on:
   schedule:
     # Every Monday at 05:00 UTC (after ui-automation.yml at 04:00)
     - cron: "0 5 * * 1"
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 permissions: {}
 
@@ -24,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup .NET
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
@@ -73,7 +80,7 @@ jobs:
           pwsh -ExecutionPolicy Bypass -File scripts/game/prove-features-gate.ps1 -RequireGame
 
       - name: Upload test results
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         if: always()
         with:
           name: game-launch-results
@@ -81,7 +88,7 @@ jobs:
           retention-days: 14
 
       - name: Upload in-game UI test results (from BepInEx log)
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         if: always()
         with:
           name: overlay-ui-results

--- a/.github/workflows/inline-json-options.yml
+++ b/.github/workflows/inline-json-options.yml
@@ -1,4 +1,11 @@
 name: inline-json-options
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 # Pattern #109 detection gate — fails CI when production code constructs
 # ad-hoc ``new JsonSerializerOptions { ... }`` literals outside designated
@@ -27,10 +34,6 @@ on:
       - "docs/qa/inline-json-options-allowlist.txt"
       - ".github/workflows/inline-json-options.yml"
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   inline-json-options-check:
     name: Pattern #109 inline-json-options
@@ -38,10 +41,10 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: "3.12"
 
@@ -53,7 +56,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: inline-json-options-report
           path: docs/qa/inline-json-options-report.json

--- a/.github/workflows/journey-quality-gates.yml
+++ b/.github/workflows/journey-quality-gates.yml
@@ -1,4 +1,11 @@
 name: Journey Quality Gates
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   pull_request:
@@ -8,15 +15,11 @@ on:
       - '.github/workflows/journey-quality-gates.yml'
   push:
     branches: [main]
-
-permissions:
-  contents: read
-
 jobs:
   validate-journeys:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
         with:
           submodules: true
       
@@ -76,7 +79,7 @@ jobs:
   manifest-count:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
       
       - name: Report manifest count
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup .NET
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
@@ -58,7 +58,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/logerror-no-stack.yml
+++ b/.github/workflows/logerror-no-stack.yml
@@ -1,4 +1,11 @@
 name: logerror-no-stack
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 # Pattern #96 detection gate — fails CI when a C# log call drops the
 # exception stack trace (e.g. ``LogError($"...{ex.Message}")`` or
@@ -27,10 +34,6 @@ on:
       - "docs/qa/logerror-no-stack-allowlist.txt"
       - ".github/workflows/logerror-no-stack.yml"
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   logerror-no-stack-check:
     name: Pattern #96 logerror-no-stack
@@ -38,10 +41,10 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: "3.12"
 
@@ -53,7 +56,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: logerror-no-stack-report
           path: docs/qa/logerror-no-stack-report.json

--- a/.github/workflows/mcp-pytest.yml
+++ b/.github/workflows/mcp-pytest.yml
@@ -1,4 +1,11 @@
 name: MCP Server Pytest Suite
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
@@ -12,10 +19,6 @@ on:
       - 'src/Tools/DinoforgeMcp/**'
       - '.github/workflows/mcp-pytest.yml'
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   test:
     name: Pytest Suite
@@ -30,10 +33,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -67,7 +70,7 @@ jobs:
           fail_ci_if_error: false
 
       - name: Upload test results
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         if: always()
         with:
           name: test-results-${{ matrix.python-version }}
@@ -101,15 +104,12 @@ jobs:
   lint:
     name: Code Quality
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: "3.11"
           cache: pip
@@ -145,15 +145,12 @@ jobs:
     name: Integration Tests
     runs-on: ubuntu-latest
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: "3.11"
           cache: pip
@@ -176,9 +173,6 @@ jobs:
     needs: [test, lint]
     runs-on: ubuntu-latest
     if: always()
-    permissions:
-      contents: read
-
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -1,13 +1,16 @@
 name: Mutation Testing
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   workflow_dispatch:
   schedule:
     - cron: '0 3 * * 0'  # Sunday 3am UTC
-
-permissions:
-  contents: read
-
 jobs:
   stryker:
     name: Stryker Mutation Testing
@@ -15,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup .NET
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
@@ -89,7 +92,7 @@ jobs:
           PYEOF
 
       - name: Upload mutation test results
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         if: always()
         with:
           name: mutation-test-results

--- a/.github/workflows/orphan-process-start.yml
+++ b/.github/workflows/orphan-process-start.yml
@@ -1,4 +1,11 @@
 name: orphan-process-start
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 # Pattern #102 detection gate — fails CI when production C# code calls
 # ``Process.Start(...)`` in a way that orphans the Process handle.
@@ -41,10 +48,6 @@ on:
       - "docs/qa/orphan-process-start-allowlist.txt"
       - ".github/workflows/orphan-process-start.yml"
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   orphan-process-start-check:
     name: Pattern #102 orphan-process-start
@@ -52,10 +55,10 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: "3.12"
 
@@ -67,7 +70,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: orphan-process-start-report
           path: docs/qa/orphan-process-start-report.json

--- a/.github/workflows/pack-screenshots.yml
+++ b/.github/workflows/pack-screenshots.yml
@@ -10,6 +10,13 @@ on:
   schedule:
     # Weekly Sunday at 2:00 UTC (intentionally off-minute per feedback_parallel_subagent_minimum)
     - cron: "7 2 * * 0"
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   capture:

--- a/.github/workflows/pack-validation.yml
+++ b/.github/workflows/pack-validation.yml
@@ -5,9 +5,6 @@ on:
     paths:
       - 'packs/**'
       - '.github/workflows/pack-validation.yml'
-
-permissions:
-  contents: read
   pull-requests: write
 
 jobs:
@@ -149,3 +146,10 @@ jobs:
       - name: Fail workflow if validation failed
         if: steps.status.outputs.failed == '1'
         run: exit 1
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+

--- a/.github/workflows/pattern-gates.yml
+++ b/.github/workflows/pattern-gates.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
-
-permissions:
-  contents: read
   checks: write
   pull-requests: write
 
@@ -78,10 +75,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: '3.11'
 
@@ -92,7 +89,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: pattern-${{ matrix.pattern.number }}-report
           path: pattern-${{ matrix.pattern.number }}-report.json
@@ -105,10 +102,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: '3.11'
 
@@ -125,10 +122,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: '3.11'
 
@@ -145,10 +142,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: '3.11'
 
@@ -165,10 +162,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: '3.11'
 
@@ -185,10 +182,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: '3.11'
 
@@ -197,3 +194,10 @@ jobs:
 
       - name: Run Pattern #223 detection
         run: python scripts/ci/audit_todo_without_ticket.py
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+

--- a/.github/workflows/perf-benchmarks.yml
+++ b/.github/workflows/perf-benchmarks.yml
@@ -5,6 +5,13 @@ on:
     # Run nightly at 2 AM UTC (10 PM EDT)
     - cron: '0 2 * * *'
   workflow_dispatch:
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   benchmark:

--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -3,9 +3,6 @@ name: Policy Gate
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-
-permissions:
-  contents: read
   pull-requests: read
 
 jobs:
@@ -13,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Governance Checks
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
         with:
           fetch-depth: 0
 
@@ -131,3 +128,10 @@ jobs:
       - name: Summary
         if: success()
         run: echo "All governance checks passed"
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+

--- a/.github/workflows/polyglot-build.yml
+++ b/.github/workflows/polyglot-build.yml
@@ -11,13 +11,15 @@ on:
       - '.github/workflows/polyglot-build.yml'
   pull_request:
     branches: [main]
-
-permissions: {}
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+
+permissions: {}
 jobs:
   build-rust:
     # Matrix pattern-gates cover PRs; full multi-platform Rust builds run on main push only.
@@ -48,12 +50,9 @@ jobs:
             runner: macos-x64
             rust-target: x86_64-apple-darwin
             artifact-name: libdinoforge_asset_pipeline.dylib
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -62,7 +61,7 @@ jobs:
           targets: ${{ matrix.rust-target }}
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.7.7
+        uses: Swatinem/rust-cache@874b06e0d3f63371f9ddbee43d4c8ebc73021583 # v-latest
         with:
           workspaces: src/Tools/AssetPipelineRust
 
@@ -75,7 +74,7 @@ jobs:
         run: cargo test --release --target ${{ matrix.rust-target }}
 
       - name: Upload Rust artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: rust-asset-pipeline-${{ matrix.runner }}
           path: src/Tools/AssetPipelineRust/target/${{ matrix.rust-target }}/release/${{ matrix.artifact-name }}
@@ -113,15 +112,12 @@ jobs:
             go-os: darwin
             go-arch: amd64
             binary-name: dinoforge-resolver
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: actions/setup-go@78961f6f84d799cd858575bb931c3e51d3b13290 # v-latest
         with:
           go-version: '1.22'
           cache: true
@@ -144,7 +140,7 @@ jobs:
         run: go test -v ./...
 
       - name: Upload Go artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: go-resolver-${{ matrix.runner }}
           path: src/Tools/DependencyResolver/bin/${{ matrix.binary-name }}
@@ -177,12 +173,9 @@ jobs:
             runner: macos-x64
             zig-target: x86_64-macos
             artifact-name: dinoforge_asset_pipeline_zig.dylib
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup Zig
         uses: goto-bus-stop/setup-zig@7ab2955eb728f5440978d5824358023be3a2802d # v2.2.0
@@ -218,7 +211,7 @@ jobs:
           fi
 
       - name: Upload Zig artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: zig-asset-pipeline-${{ matrix.runner }}
           path: src/Tools/AssetPipelineZig/zig-out/lib/
@@ -231,15 +224,12 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
@@ -254,7 +244,7 @@ jobs:
         run: pytest tests/ -v --cov=dinoforge_mcp --cov-report=xml
 
       - name: Upload coverage to artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: python-coverage-${{ matrix.python-version }}
           path: src/Tools/DinoforgeMcp/coverage.xml
@@ -266,12 +256,9 @@ jobs:
     name: Build PlayCUA (Rust isolation layer)
     continue-on-error: true
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Clone PlayCUA repository
         run: |
@@ -286,7 +273,7 @@ jobs:
           toolchain: stable
 
       - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.7.7
+        uses: Swatinem/rust-cache@874b06e0d3f63371f9ddbee43d4c8ebc73021583 # v-latest
         with:
           workspaces: /tmp/playcua
 
@@ -309,7 +296,7 @@ jobs:
           ls -lh playcua-release/
 
       - name: Upload PlayCUA artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: playcua-release-ubuntu
           path: playcua-release/
@@ -321,9 +308,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-rust, build-go, build-zig, build-python, build-playcua]
     if: always()
-    permissions:
-      contents: read
-
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -357,7 +341,7 @@ jobs:
           cat artifact-summary.txt
 
       - name: Upload artifact summary
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: polyglot-artifact-summary
           path: artifact-summary.txt
@@ -389,12 +373,9 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     needs: [build-python]
-    permissions:
-      contents: read
-
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup .NET
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0

--- a/.github/workflows/proof-gate.yml
+++ b/.github/workflows/proof-gate.yml
@@ -1,4 +1,11 @@
 name: Proof Gate
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   pull_request:
@@ -6,10 +13,6 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   proof-gate:
     name: prove-features-gate
@@ -18,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: '3.11'
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,12 +1,15 @@
 name: Release Drafter
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
     branches: [main]
-
-permissions:
-  contents: read
-
 jobs:
   release-drafter:
     # SHA-pinned per #805; flat workflows path (subdirs not supported for reusable workflows)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,13 @@ on:
         description: 'Tag to build retroactive release for (e.g. v0.9.0)'
         required: true
         type: string
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 permissions: {}
 
@@ -24,7 +31,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
         with:
           fetch-depth: 0
           # For workflow_dispatch retro-runs, check out the specific tag's commit
@@ -98,7 +105,7 @@ jobs:
           --verbosity normal
 
       - name: Upload test results
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         if: always()
         with:
           name: test-results
@@ -370,7 +377,7 @@ jobs:
       # Build Go DependencyResolver binary
       # ---------------------------------------------------------------
       - name: Setup Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        uses: actions/setup-go@78961f6f84d799cd858575bb931c3e51d3b13290 # v-latest
         with:
           go-version: '1.22'
 
@@ -724,11 +731,11 @@ jobs:
             staging/SHA256SUMS.txt
           fail_on_unmatched_files: false
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
 
       # Upload Desktop Companion (optional — skipped if VS Build Tools unavailable)
       - name: Upload Desktop Companion
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: desktop-companion
           path: |

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -6,6 +6,13 @@ on:
   release:
     types: [published]
   workflow_dispatch:
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 permissions: {}
 
@@ -17,7 +24,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup .NET 8
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0 
@@ -45,7 +52,7 @@ jobs:
             --json
 
       - name: Upload SBOMs as artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: sbom-files
           path: |

--- a/.github/workflows/schema-drift.yml
+++ b/.github/workflows/schema-drift.yml
@@ -1,4 +1,11 @@
 name: schema-drift
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 # Pattern #90 detection gate — fails CI when schemas/ silently de-syncs from
 # its callers: missing schema files referenced by C# code, broken `$ref`
@@ -30,10 +37,6 @@ on:
       - "docs/qa/schema-drift-allowlist.txt"
       - ".github/workflows/schema-drift.yml"
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   schema-drift-check:
     name: Pattern #90 schema-drift
@@ -41,10 +44,10 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: "3.12"
 
@@ -59,7 +62,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: schema-drift-report
           path: docs/qa/schema-drift-report.json

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   actions: read
   contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 jobs:
   analysis:
@@ -23,19 +27,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        uses: ossf/scorecard-action@af76153369ae1eb1eaffc4118046b7fda9a8419e # v-latest
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/security-guard.yml
+++ b/.github/workflows/security-guard.yml
@@ -5,6 +5,13 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 permissions: {}
 
@@ -16,7 +23,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3
@@ -44,12 +51,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
         with:
           fetch-depth: 0
 
       - name: TruffleHog Secret Scan
-        uses: trufflesecurity/trufflehog@6c64db94d5b2e09d7e0948fb6bd3166cc6fffbc7 # v3.94.0
+        uses: trufflesecurity/trufflehog@75add79b929b263dae147d2e5bcf0daf292165cf # v-latest
         with:
           extra_args: --only-verified
 
@@ -59,7 +66,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup .NET
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0

--- a/.github/workflows/stringly-enums.yml
+++ b/.github/workflows/stringly-enums.yml
@@ -1,4 +1,11 @@
 name: stringly-enums
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 # Pattern #101 detection gate — fails CI when production C# model
 # code declares ``public string <Name>(Type|Mode|Status|Phase|Kind|
@@ -32,10 +39,6 @@ on:
       - "docs/qa/stringly-enums-allowlist.txt"
       - ".github/workflows/stringly-enums.yml"
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   stringly-enums-check:
     name: Pattern #101 stringly-enums
@@ -43,10 +46,10 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: "3.12"
 
@@ -58,7 +61,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: stringly-enums-report
           path: docs/qa/stringly-enums-report.json

--- a/.github/workflows/tautological-test.yml
+++ b/.github/workflows/tautological-test.yml
@@ -1,4 +1,11 @@
 name: tautological-test
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 # Pattern #91 detection gate — fails CI when any [Fact]/[Theory] body
 # matches the tautological signatures (true.Should().BeTrue, Assert.True(true),
@@ -23,10 +30,6 @@ on:
       - "docs/qa/known-tautological-tests.txt"
       - ".github/workflows/tautological-test.yml"
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   tautological-test-check:
     name: Pattern #91 detection
@@ -34,10 +37,10 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: "3.12"
 
@@ -49,7 +52,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: tautological-test-report
           path: docs/qa/tautological-test-report.json

--- a/.github/workflows/tcs-sync-continuation.yml
+++ b/.github/workflows/tcs-sync-continuation.yml
@@ -1,4 +1,11 @@
 name: tcs-sync-continuation
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 # Pattern #97 detection gate — fails CI when a C# call site constructs
 # a ``TaskCompletionSource`` or ``TaskCompletionSource<T>`` without
@@ -29,10 +36,6 @@ on:
       - "docs/qa/tcs-sync-continuation-allowlist.txt"
       - ".github/workflows/tcs-sync-continuation.yml"
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   tcs-sync-continuation-check:
     name: Pattern #97 tcs-sync-continuation
@@ -40,10 +43,10 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: "3.12"
 
@@ -55,7 +58,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: tcs-sync-continuation-report
           path: docs/qa/tcs-sync-continuation-report.json

--- a/.github/workflows/test-isolation.yml
+++ b/.github/workflows/test-isolation.yml
@@ -43,10 +43,10 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: "3.12"
 
@@ -58,7 +58,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: global-state-report
           path: docs/qa/global-state-report.json

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,20 +1,23 @@
 name: Trufflehog Secrets Scan
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [main]
   pull_request:
-
-permissions:
-  contents: read
-
 jobs:
   trufflehog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
         with:
           fetch-depth: 0
       - name: Secret Scanning
-        uses: trufflesecurity/trufflehog@a795abf9397540a3e7c4846105b5a89f39d0d053 # v3.82.x
+        uses: trufflesecurity/trufflehog@75add79b929b263dae147d2e5bcf0daf292165cf # v-latest
         with:
           extra_args: --results=verified

--- a/.github/workflows/ui-automation.yml
+++ b/.github/workflows/ui-automation.yml
@@ -5,6 +5,13 @@ on:
   schedule:
     # Every Monday at 04:00 UTC
     - cron: "0 4 * * 1"
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 permissions: {}
 
@@ -19,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup .NET
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0
@@ -52,7 +59,7 @@ jobs:
             --results-directory ./test-results
 
       - name: Upload test results
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         if: always()
         with:
           name: ui-automation-results

--- a/.github/workflows/unbounded-constraints.yml
+++ b/.github/workflows/unbounded-constraints.yml
@@ -1,4 +1,11 @@
 name: unbounded-constraints
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 # Pattern #94 generalization gate (#261). Pairs with the narrow
 # framework-version gate (#260, scripts/ci/check_framework_version.py).
@@ -45,10 +52,6 @@ on:
       - "docs/qa/unbounded-constraints-allowlist.txt"
       - ".github/workflows/unbounded-constraints.yml"
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   unbounded-constraints-check:
     name: Pattern #94 generalized unbounded-constraints
@@ -56,10 +59,10 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: "3.12"
 
@@ -74,7 +77,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: unbounded-constraints-report
           path: docs/qa/unbounded-constraints-report.json

--- a/.github/workflows/unguarded-deserialize.yml
+++ b/.github/workflows/unguarded-deserialize.yml
@@ -1,4 +1,11 @@
 name: unguarded-deserialize
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 # Pattern #95 detection gate — fails CI when a cross-FFI C# call site
 # deserializes a typed DTO without IValidatable + JsonGuard pairing.
@@ -30,10 +37,6 @@ on:
       - "docs/qa/unguarded-deserialize-allowlist.txt"
       - ".github/workflows/unguarded-deserialize.yml"
   workflow_dispatch:
-
-permissions:
-  contents: read
-
 jobs:
   unguarded-deserialize-check:
     name: Pattern #95 unguarded-deserialize
@@ -41,10 +44,10 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@c8813ba1bc76ebf779b911ad8ffccbf2e449cb48 # v-latest
         with:
           python-version: "3.12"
 
@@ -56,7 +59,7 @@ jobs:
 
       - name: Upload report on failure
         if: failure()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v-latest
         with:
           name: unguarded-deserialize-report
           path: docs/qa/unguarded-deserialize-report.json

--- a/.github/workflows/validate-packs.yml
+++ b/.github/workflows/validate-packs.yml
@@ -1,4 +1,11 @@
 name: Validate Packs
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 on:
   push:
@@ -15,10 +22,6 @@ on:
       - "schemas/**"
       - "src/Tools/PackCompiler/**"
       - "src/SDK/**"
-
-permissions:
-  contents: read
-
 jobs:
   validate:
     name: Validate Content Packs
@@ -26,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
 
       - name: Setup .NET 8.0
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -7,6 +7,13 @@ on:
         description: 'Dry run (no commits or tags)'
         type: boolean
         default: false
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 
 permissions: {}
 
@@ -19,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
 
       - name: Setup .NET 8
         uses: actions/setup-dotnet@4d6c8fcf3c8f7a60068d26b594648e99df24cee3 # v4.0.0


### PR DESCRIPTION
## **User description**
Org-wide workflow hygiene (continuation). Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Repinned actions plus tightened default permissions can break auto-merge, PR benchmark comments, and scheduled doc/badge pushes if grants are missing or YAML permission blocks are invalid.
> 
> **Overview**
> Org-wide **GitHub Actions hygiene** across `.github/workflows`: third-party steps are repinned (notably `actions/checkout` from v6 SHAs to `df4cb1c…` v4, unified `actions/upload-artifact@043fb46…`, and refreshed `setup-python`, `setup-node`, `setup-go`, `github-script`, TruffleHog, Scorecard, and Pages deploy/upload SHAs).
> 
> Most workflows now declare **default `permissions: contents: read`** and **`concurrency`** with `cancel-in-progress: true` (often at the file footer). Jobs that need more scope keep **job-level overrides** (e.g. deploy jobs with `contents: write`, CodeQL `security-events: write`).
> 
> Token usage shifts from **`secrets.GITHUB_TOKEN` to `github.token`** in gh-pages, badge updates, and release upload steps.
> 
> **Verify after merge:** `agent-merge-on-bot-approve` removed workflow **`contents: write`** and may have **`pull-requests` / `checks` nested under `on:`** instead of `permissions`. **`benchmark-regression-gate`** dropped workflow-level **`pull-requests: write`**. **`ci-status-badges` / `dashboard`** use `contents: read` at workflow level but still **push commits**. **`polyglot-build`** and **`game-launch`** have **duplicate `permissions`** blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 313cb012e0f7f5d400dde09c36b091494285fbc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Tighten and stabilize repository workflows**

### What Changed
- Most workflows now stop duplicate runs on the same branch, so new commits cancel older in-progress workflow runs
- Common workflow actions were updated to newer pinned versions, including checkout, upload artifact, Python, Node, Go, and Rust-related steps
- Several workflows now use the built-in GitHub token directly for publishing badges, pages, releases, and similar updates
- Workflow access was narrowed in many places to read-only by default, while write access stays only where publishing or merge actions need it

### Impact
`✅ Fewer duplicate CI runs`
`✅ Safer workflow permissions`
`✅ More reliable badge, release, and page updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated 40+ GitHub Actions workflow files with standardized configurations.
  * Adjusted repository access permissions in CI/CD workflows to read-only mode.
  * Added concurrency controls to workflow execution, grouping runs by workflow and branch reference.
  * Updated GitHub Actions dependencies (checkout, setup-python, upload-artifact, and others) to newer pinned versions.
  * Streamlined token references to use standardized GitHub token format across workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->