### PR TITLE
chore(Dino): shell-script hygiene

### DIFF
--- a/deploy-debug.sh
+++ b/deploy-debug.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Deploy debug version of DINOForge.Runtime.dll
 
 SRC="C:/Users/koosh/Dino/src/Runtime/bin/Debug/netstandard2.0/DINOForge.Runtime.dll"

--- a/scripts/build-telemetry-view.sh
+++ b/scripts/build-telemetry-view.sh
@@ -1,5 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
+set -euo pipefail
 #
 # build-telemetry-view.sh — Generates a self-contained HTML telemetry viewer from DINOForge metrics
 #

--- a/scripts/install-dev-tools.sh
+++ b/scripts/install-dev-tools.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 #
 # Install DINOForge optional development tools (UnityExplorer, etc.)
 #

--- a/scripts/install/install-dumptools.sh
+++ b/scripts/install/install-dumptools.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Install DumpTools CLI tool for DINOForge
 
 set -e

--- a/scripts/install/install-packcompiler.sh
+++ b/scripts/install/install-packcompiler.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Install PackCompiler CLI tool for DINOForge
 
 set -e

--- a/scripts/task-wrapper.sh
+++ b/scripts/task-wrapper.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 set -e
 
 TASK="${1:-build:all}"

--- a/scripts/verify_headless.sh
+++ b/scripts/verify_headless.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 # Headless Automation Verification Script
 # Validates that DINOForge can run automated game tests without manual game launches
 

--- a/test_packs.sh
+++ b/test_packs.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 set -e
 
 echo "=== Testing Pack Loading ==="


### PR DESCRIPTION
## **User description**
Normalize Bash shebangs to #!/usr/bin/env bash and enable strict shell mode (set -euo pipefail) for safer script execution across repo shell entry points. Scope: mechanical, non-functional hygiene. No logic or quoting changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical shebang and strict-mode additions only; no application, auth, or data-path logic changed.
> 
> **Overview**
> **Shell entry points** across deploy, install, task, test, and telemetry scripts now use `#!/usr/bin/env bash` instead of `#!/bin/bash`, and each touched script adds **`set -euo pipefail`** near the top so failures, unset variables, and pipeline errors stop execution early.
> 
> Affected paths include `deploy-debug.sh`, `scripts/build-telemetry-view.sh`, `scripts/install-dev-tools.sh`, `scripts/install/install-dumptools.sh`, `scripts/install/install-packcompiler.sh`, `scripts/task-wrapper.sh`, `scripts/verify_headless.sh`, and `test_packs.sh`. **No script logic or quoting was changed** in this diff; some files still have a later redundant `set -e` that predates this hygiene pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55e5d16498a0531e66b1096bdf3a46d4636d1b4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Standardize repo shell scripts and make them fail fast on errors**

### What Changed
- Repo shell entry points now use a portable Bash launcher line instead of a fixed path
- These scripts now stop immediately when a command fails, a value is missing, or an unset variable is used
- The change covers install, deploy, task, test, and telemetry scripts used for local and CI workflows

### Impact
`✅ Fewer silent script failures`
`✅ More reliable install and deploy runs`
`✅ Safer local and CI shell execution`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
