### PR TITLE
wip(bldicons): salvage pre-capacity-death work

### DIFF
--- a/.cursor/cli.json
+++ b/.cursor/cli.json
@@ -1,7 +1,8 @@
 {
   "permissions": {
-    "allow": ["Shell(**)"],
+    "allow": [
+      "Shell(**)"
+    ],
     "deny": []
-  },
-  "approvalMode": "unrestricted"
+  }
 }

--- a/docs/sessions/build-panel-icons-989-20260531.md
+++ b/docs/sessions/build-panel-icons-989-20260531.md
@@ -1,0 +1,19 @@
+# DINOForge #989 — Build-Panel Icons Regression
+
+## Investigation
+- Branch: `feat/bldicons-20260531`
+- Files reviewed: `src/Runtime/UI/CanvasReskinner.cs`, `src/Runtime/UI/NativeMenuInjector.cs`, `src/Runtime/UI/NativeUiHelper.cs`, `src/Runtime/UI/ModMenuPanel.cs`
+- No active sprite-null assignments were found in `CanvasReskinner.cs` and `ModMenuPanel.cs`.
+- In `NativeUiHelper.CopySelectableVisualState`, we found an unconditional assignment that could clear visuals:
+  - `src/Runtime/UI/NativeUiHelper.cs:245` → `resolvedImage.sprite = donorImage.sprite;`
+- In `NativeMenuInjector.CopyImageVisualStyle`, we found another unconditional assignment that could clear visuals:
+  - `src/Runtime/UI/NativeMenuInjector.cs:1696` → `target.sprite = source.sprite;`
+
+## Fix
+- Guarded both sprite copies to only write when the donor sprite is non-null.
+- This keeps existing cloned/background sprites intact when source sprites are missing.
+- If a donor sprite is available, existing copy behavior remains unchanged.
+
+## Build status
+- Command: `dotnet build src/Runtime`
+- Result: exited 0 (success)

--- a/src/Runtime/UI/NativeMenuInjector.cs
+++ b/src/Runtime/UI/NativeMenuInjector.cs
@@ -1693,7 +1693,10 @@ namespace DINOForge.Runtime.UI
                 return;
             }
 
-            target.sprite = source.sprite;
+            if (source.sprite != null)
+            {
+                target.sprite = source.sprite;
+            }
             target.type = source.type;
             target.color = source.color;
             // #R1: carry the donor's material so a custom-shader native frame keeps its

--- a/src/Runtime/UI/NativeUiHelper.cs
+++ b/src/Runtime/UI/NativeUiHelper.cs
@@ -242,7 +242,10 @@ namespace DINOForge.Runtime.UI
 
                 if (resolvedTargetGraphic is Image resolvedImage && donor.targetGraphic is Image donorImage)
                 {
-                    resolvedImage.sprite = donorImage.sprite;
+                    if (donorImage.sprite != null)
+                    {
+                        resolvedImage.sprite = donorImage.sprite;
+                    }
                     resolvedImage.type = donorImage.type;
                     resolvedImage.color = donorImage.color;
                     resolvedImage.material = donorImage.material;


### PR DESCRIPTION
## **User description**
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, defensive UI visual-sync change with no auth or data impact; behavior when donors have sprites is unchanged.
> 
> **Overview**
> Fixes **#989** build-panel icon regression by stopping native UI clone paths from **clearing** target sprites when the donor/source sprite is missing.
> 
> **Runtime:** `CopyImageVisualStyle` in `NativeMenuInjector` and `CopySelectableVisualState` in `NativeUiHelper` now assign `target.sprite` only when `source.sprite` / `donorImage.sprite` is non-null. Other visual properties (type, color, material, PPU, etc.) are still copied as before.
> 
> **Docs/config:** Adds session notes in `docs/sessions/build-panel-icons-989-20260531.md` (investigation + verified `dotnet build src/Runtime`). Minor formatting-only edits to `.cursor/cli.json` (drops `approvalMode`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80b8747fa6379321cf1830cd908b4fcfdf43bb24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Keep build-panel icons visible when donor sprites are missing**

### What Changed
- Build-panel and cloned UI images no longer get cleared when the source sprite is missing
- Existing icons stay in place unless a replacement sprite is actually available
- Added a session note documenting the investigation, fix, and successful build check

### Impact
`✅ Fewer missing build-panel icons`
`✅ Less visual regression in cloned UI`
`✅ Clearer build-fix tracking`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
