### PR TITLE
docs(agileplus): reconcile EPIC-027 catalog with shipped v0.27.0 work — FR-021..023 + NFR-023..025 + SW-014 + Mermaid + 0-orphan matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — EPIC-027 Spec & Traceability (v0.27.0)
+- **EPIC-027 FR/NFR catalog reconciled with shipped work** — added `EPIC-027-FR-021` (steam_appid process survival), `FR-022` (native quick MODS panel + Browse-all), `FR-023` (deterministic single-TC selection / `.disabled` roster + `warfare-naval`); added `NFR-023` (Aviation manual `EntityQuery`, no codegen `Entities.ForEach`), `NFR-024` (Newtonsoft static `JsonConvert.SerializeObject`), `NFR-025` (real-mesh bundle conversion gate, ≥14/36 SW bundles) (`docs/specs/v0.27.0/requirements.md`)
+- **Story SW-014 — Runtime Survival & v0.27.0 Reconcile** — new AgilePlus WorkPackage (sequence 14, state `done`) covering steam_appid auto-provision, Aviation codegen fix, Newtonsoft fix, quick MODS panel, pack-cut; full Evidence Requirements table (`docs/specs/v0.27.0/runtime-survival-reconcile.md`)
+- **Traceability matrix: EPIC-027 FR table added + NFR rows extended** — every FR-001..023 and NFR-001..025 maps to an owning story with an AgilePlus `EvidenceType`; 0 orphans, 0 dangling refs verified (`docs/specs/traceability-matrix.md`)
+- **EPIC-027 Mermaid traceability/dependency diagram** — epic → stories → requirements graph with load-bearing story dependencies (`docs/specs/v0.27.0-full-conversion-epic.md`)
+
+### Changed
+- **EPIC-027 epic state → Implementing; `agileplus_spec_hash` recomputed** (SHA256 `18D1CBD2…D8ACFC9`); child-story table + sprint totals updated for SW-014 (144 excl-stretch / 157 incl-stretch points)
+
+### Fixed
+- **AgilePlus conformance: invalid `CodeReview` evidence type → `ReviewApproval`** in 5 EPIC-027 stories (SW-001/004/005/006/007) — `EvidenceType` enum has no `CodeReview` variant
+
+
 ## [0.26.0] - 2026-05-28
 
 ### Added — Major Features (35+ commits)

--- a/docs/specs/traceability-matrix.md
+++ b/docs/specs/traceability-matrix.md
@@ -360,6 +360,41 @@ public class PackLoadingTests
 
 ---
 
+## EPIC-027 FR Traceability (v0.27.0)
+
+Every shipped EPIC-027 functional requirement maps to an owning story (AgilePlus WorkPackage)
+and an evidence type. NFRs are carried as FR-NNN IDs (`fr_id` FK) in the table below this one.
+0 orphans: each FR/NFR has at least one owning story; each story declares its requirements in
+its `**Requirements**:` front-matter line.
+
+| FR ID | Owning Stories | Evidence Type | Description |
+|-------|----------------|---------------|-------------|
+| EPIC-027-FR-001 | SW-001 | ManualAttestation | Native Mods button opens `DINOForge_ModsPage`. |
+| EPIC-027-FR-002 | SW-001 | ManualAttestation | Mods page lists packs w/ name+version+status; empty state message. |
+| EPIC-027-FR-003 | SW-001 | ManualAttestation | Page closes cleanly; no duplicate rows on re-scan. |
+| EPIC-027-FR-004 | SW-001 | ManualAttestation | F10 toggles Mods; F9 toggles Debug (Win32 key path). |
+| EPIC-027-FR-005 | SW-002 | ManualAttestation | DINOForge version badge in window title while pack active. |
+| EPIC-027-FR-006 | SW-002 | ManualAttestation | Window icon overridden when TC pack declares `window_icon`. |
+| EPIC-027-FR-007 | SW-003 | TestResult | All 30 SW unit bundles are non-stub Unity 2021.3.45f2 bundles. |
+| EPIC-027-FR-008 | SW-003 | CiOutput | `dinoforge verify-mod` exits 0 with 0 stub-bundle errors. |
+| EPIC-027-FR-009 | SW-004 | ManualAttestation | Loading screen replaced while TC pack active. |
+| EPIC-027-FR-010 | SW-005 | ManualAttestation | Mod brand identity applied to menu; no vanilla art. |
+| EPIC-027-FR-011 | SW-006 | ManualAttestation | ThemeEngine applies faction palette to HUD across 7 phases. |
+| EPIC-027-FR-012 | SW-006 | CiOutput | PackCompiler rejects malformed `ui_theme`; valid passes. |
+| EPIC-027-FR-013 | SW-007 | ManualAttestation | 2D takeover: unit portraits + faction emblems replaced. |
+| EPIC-027-FR-014 | SW-007 | ReviewApproval | Sprite-swap strategy confirmed/activated per discovery pass. |
+| EPIC-027-FR-015 | SW-008 | CiOutput | PackCompiler validate exits 0; 0 dangling refs; coverage met. |
+| EPIC-027-FR-016 | SW-009 | ManualAttestation | Themed projectiles visible during combat for both mods. |
+| EPIC-027-FR-017 | SW-010 | ManualAttestation | Naval units build, traverse water, engage targets. |
+| EPIC-027-FR-018 | SW-011 | ManualAttestation | Aerial units (airports/airplanes) spawn, pathfind, attack. |
+| EPIC-027-FR-019 | SW-012 | ManualAttestation | Audio takeover: menu+ambient music replaced; crossfade. |
+| EPIC-027-FR-020 | SW-001, SW-008 | ManualAttestation | Pack toggle updates badge; `dinoforge status` reflects it. |
+| EPIC-027-FR-021 | SW-014 | ManualAttestation | `steam_appid.txt` auto-provisioned; injected process survives launch. |
+| EPIC-027-FR-022 | SW-001, SW-014 | ManualAttestation | Quick MODS panel = default click; Browse-all escalates. |
+| EPIC-027-FR-023 | SW-008, SW-014 | ReviewApproval | Deterministic single-TC selection; `.disabled` roster; `warfare-naval`. |
+
+---
+
 ## EPIC-027 NFR Traceability (v0.27.0)
 
 | NFR ID | Category | Owning Stories | Description |
@@ -385,6 +420,9 @@ public class PackLoadingTests
 | EPIC-027-NFR-020 | Visual | SW-005, SW-007, SW-008 | No vanilla DINO medieval 2D art visible with TC active (judge receipt) |
 | EPIC-027-NFR-021 | Visual | SW-005, SW-008 | Faction emblems + unit portraits visible in-game for both mods |
 | EPIC-027-NFR-022 | Legal | SW-008, SW-012 | Asset licensing manifest complete; all shipped audio/images/3D documented as original or CC0; `LICENSE-audio.md`/`LICENSE-assets.md` present in each pack |
+| EPIC-027-NFR-023 | Stability | SW-011, SW-014 | Aerial/Aviation ECS uses manual `EntityQuery` loops, not codegen `Entities.ForEach`; no Burst/codegen TypeLoadException under BepInEx Mono |
+| EPIC-027-NFR-024 | Stability | SW-014 | Update-check uses static `JsonConvert.SerializeObject` overload; no MethodNotFound under BepInEx Newtonsoft.Json |
+| EPIC-027-NFR-025 | Asset Gate | SW-003, SW-008, SW-014 | Real-mesh bundle conversion tracked vs roster; >=14/36 SW bundles wire real meshes; `convert_real_models.py` reproducible; remaining stubs logged |
 
 ---
 
@@ -400,6 +438,7 @@ public class PackLoadingTests
 | WP01-006 | US-F6.1 Pack Compiler | `PackCompilerCliTests.*` |
 | WP01-007 | US-F7.1 Entity Inspector | `UnitSpawnerTests.*` |
 | WP01-008 | US-F8.1 Desktop Companion | `CompanionTests.*` |
+| SW-001..SW-014 | EPIC-027 Full-Conversion | per-story Evidence Requirements (see `docs/specs/v0.27.0/`) |
 
 ---
 

--- a/docs/specs/v0.27.0-full-conversion-epic.md
+++ b/docs/specs/v0.27.0-full-conversion-epic.md
@@ -1,11 +1,11 @@
 # EPIC-027: True Full-Conversion Experience
 
-**Status**: Proposed
+**Status**: Implementing  <!-- AgilePlus FeatureState: implementing (SW-001..SW-014 in progress; SW-014 survival/reconcile done) -->
 **Date**: 2026-05-28
 **Author**: DINOForge Agents
 **Version Target**: v0.27.0
 **AgilePlus Stories**: SW-001 through SW-013 (see `docs/specs/v0.27.0/`)
-**agileplus_spec_hash**: 4D4856F109ED5094F6B05A9599C6ADA7C1D0FF743DCE244046DB5C37D5968E24  <!-- SHA256 of this file with PENDING placeholder, computed via Get-FileHash on 2026-05-29 -->
+**agileplus_spec_hash**: 18D1CBD24B6EEC425B49E6DC8B0ABD2AD859A09925ADAF4200DCAA811D8ACFC9  <!-- SHA256 of this file with PENDING placeholder, computed via Get-FileHash on 2026-05-30 -->
 
 ---
 
@@ -92,9 +92,70 @@ All implementation must respect the DINO runtime execution model
 | SW-011 | Aerial Combat Complete | 4 — Mechanics | 13 |
 | SW-012 | Audio Takeover | 4 — Mechanics | 8 |
 | SW-013 | SW Space Combat (stretch) | 5 — Stretch | 13 |
+| SW-014 | Runtime Survival & v0.27.0 Reconcile | 1 — Foundation | 13 |
 
-**Total (excluding stretch):** 131 points  
-**Total (including stretch):** 144 points
+**Total (excluding stretch):** 144 points  
+**Total (including stretch):** 157 points
+
+## Traceability & Dependency Diagram
+
+The diagram maps EPIC-027 -> stories (WorkPackages) -> requirements (FR/NFR), and the
+load-bearing story dependencies. Every shipped feature traces to at least one FR/NFR with
+evidence (see per-story Evidence Requirements tables and `requirements.md`).
+
+```mermaid
+graph TD
+  EPIC["EPIC-027<br/>Full-Conversion (Implementing)"]
+
+  subgraph S1["Sprint 1 — Foundation"]
+    SW001["SW-001 Native Mods Page"]
+    SW002["SW-002 Active Indicator"]
+    SW003["SW-003 Real Asset Bundles"]
+    SW014["SW-014 Runtime Survival & Reconcile<br/>(done)"]
+  end
+  subgraph S2["Sprint 2 — Identity"]
+    SW004["SW-004 Loading Takeover"]
+    SW005["SW-005 Brand Identity"]
+    SW006["SW-006 Reskin Engine"]
+  end
+  subgraph S3["Sprint 3 — Assets"]
+    SW007["SW-007 2D Asset Takeover"]
+    SW008["SW-008 Asset Completeness"]
+  end
+  subgraph S4["Sprint 4 — Mechanics"]
+    SW009["SW-009 Projectiles"]
+    SW010["SW-010 Naval"]
+    SW011["SW-011 Aerial"]
+    SW012["SW-012 Audio"]
+  end
+  SW013["SW-013 Space Combat (stretch)"]
+
+  EPIC --> SW001 & SW002 & SW003 & SW014
+  EPIC --> SW004 & SW005 & SW006
+  EPIC --> SW007 & SW008
+  EPIC --> SW009 & SW010 & SW011 & SW012 & SW013
+
+  %% load-bearing dependencies
+  SW003 --> SW008
+  SW003 --> SW009
+  SW009 -.soft.-> SW010
+  SW009 -.soft.-> SW011
+  SW006 --> SW004 & SW005 & SW007 & SW012 & SW013
+  SW007 --> SW008
+  SW001 --> SW014
+  SW003 --> SW014
+  SW011 --> SW014
+
+  %% requirement coverage (representative; full matrix in requirements.md)
+  SW001 -. FR-001..004,020 / NFR-001,004,007,008,015,016,017 .-> REQ
+  SW003 -. FR-007,008 / NFR-003,010,019 .-> REQ
+  SW014 -. FR-021,022,023 / NFR-002,005,006,013,023,024,025 .-> REQ
+  REQ["requirements.md<br/>FR-001..023 + NFR-001..025"]
+```
+
+> Evidence model: each requirement maps to an AgilePlus `EvidenceRequirement{fr_id, evidence_type}`
+> where `evidence_type` is one of TestResult / CiOutput / ReviewApproval / SecurityScan /
+> LintResult / ManualAttestation. NFRs are carried as FR-NNN IDs (`fr_id` FK) in the matrix.
 
 ## Related Design Documents
 

--- a/docs/specs/v0.27.0/README.md
+++ b/docs/specs/v0.27.0/README.md
@@ -2,7 +2,7 @@
 
 **Epic**: [EPIC-027](../v0.27.0-full-conversion-epic.md)
 **Target release**: v0.27.0
-**Total points (excl. stretch)**: 131 — **Total (incl. stretch)**: 144
+**Total points (excl. stretch)**: 144 — **Total (incl. stretch)**: 157
 
 ---
 
@@ -15,7 +15,7 @@ judge receipt) before it is considered done.
 
 ---
 
-### Sprint 1 — Foundation (24 points)
+### Sprint 1 — Foundation (37 points)
 
 Goal: unblock every downstream story. No identity or asset work starts until these are green.
 
@@ -24,6 +24,7 @@ Goal: unblock every downstream story. No identity or asset work starts until the
 | [SW-001](native-mods-page-visible.md) | Native Mods Page Visible | 8 | iter-146 button |
 | [SW-002](dinoforge-active-indicator.md) | DINOForge Active Indicator | 3 | Plugin.Awake |
 | [SW-003](real-asset-bundles.md) | Real Asset Bundles (kill #101) | 13 | Unity 2021.3 build |
+| [SW-014](runtime-survival-reconcile.md) | Runtime Survival & v0.27.0 Reconcile | 13 | steam_appid / SW-001/003/011 |
 
 **Sprint 1 exit criteria**:
 - `dinoforge status` shows both packs Active.

--- a/docs/specs/v0.27.0/full-ui-ux-reskin.md
+++ b/docs/specs/v0.27.0/full-ui-ux-reskin.md
@@ -176,10 +176,10 @@ All phases target v0.27.0. Phase 7 (user overrides, BepInEx config) deferred to 
 | EPIC-027-NFR-002 | CiOutput | Profiler trace (or F9 overlay log) shows no per-frame canvas traversal; theme apply completes in ≤ 1 frame per surface | Implementing → Validated |
 | EPIC-027-NFR-005 | CiOutput | CI build log (Runtime csproj `netstandard2.0`; no direct TMPro/Addressables compile refs) | Implementing → Validated |
 | EPIC-027-NFR-006 | ManualAttestation | ThemeEngine Tick drives reskin; bundles built with 2021.3.45f2 load without silent failure under BepInEx 5.4.x | Implementing → Validated |
-| EPIC-027-NFR-007 | CodeReview | No Harmony patch targets DINO ECS/UI type in SW-006 scope (grep `[HarmonyPatch` in Theme/ files) | Implementing → Validated |
-| EPIC-027-NFR-008 | CodeReview | All injected GameObjects in ThemeEngine carry `DINOForge_` prefix (grep `new GameObject` in Theme/ namespace) | Implementing → Validated |
+| EPIC-027-NFR-007 | ReviewApproval | No Harmony patch targets DINO ECS/UI type in SW-006 scope (grep `[HarmonyPatch` in Theme/ files) | Implementing → Validated |
+| EPIC-027-NFR-008 | ReviewApproval | All injected GameObjects in ThemeEngine carry `DINOForge_` prefix (grep `new GameObject` in Theme/ namespace) | Implementing → Validated |
 | EPIC-027-NFR-013 | CiOutput | `LogOutput.log` grep: no `TypeLoadException` after clean launch with ThemeEngine active | Implementing → Validated |
-| EPIC-027-NFR-015 | CodeReview | Every overlaid `Image` in ThemeEngine surfaces has `raycastTarget = false`; EventSystem guard present (Pattern #235) | Implementing → Validated |
+| EPIC-027-NFR-015 | ReviewApproval | Every overlaid `Image` in ThemeEngine surfaces has `raycastTarget = false`; EventSystem guard present (Pattern #235) | Implementing → Validated |
 | EPIC-027-NFR-016 | ManualAttestation | Mods page hover/layout matches adjacent native buttons (verified against live `dinoforge ui-tree` dump) | Implementing → Validated |
 | SW-006 | TestResult | `docs/test-results/SW-006/ThemeResolverTests.xml` (merge associativity + last-writer-wins FsCheck properties; missing-sprite graceful-degrade) | Implementing → Validated |
 | SW-006 | ManualAttestation | `MainMenuThemer.cs` removed; `MainMenuReskinner` passes all old tests (test result + code review) | Implementing → Validated |

--- a/docs/specs/v0.27.0/ingame-2d-asset-takeover.md
+++ b/docs/specs/v0.27.0/ingame-2d-asset-takeover.md
@@ -138,11 +138,11 @@ prevents the original from being allocated.
 | EPIC-027-NFR-002 | CiOutput | Profiler log confirms no per-frame canvas walk from `TcUiSpritePass`; all sprite swaps applied in single frame budget at scene load | Implementing → Validated |
 | EPIC-027-NFR-005 | CiOutput | CI build log (Runtime `netstandard2.0`; Strategy A Harmony Prefix uses reflection-resolved type, no compile-time Addressables ref) | Implementing → Validated |
 | EPIC-027-NFR-006 | ManualAttestation | Sprite bundles (if any) built with Unity 2021.3.45f2 load under BepInEx 5.4.x; `Texture2D.LoadImage` for raw PNGs confirmed on main thread (log) | Implementing → Validated |
-| EPIC-027-NFR-008 | CodeReview | All injected cursor/overlay objects carry `DINOForge_` prefix; no unnamed injected objects (grep `new GameObject` in TcCursorApplicator + TcUiSpritePass) | Implementing → Validated |
+| EPIC-027-NFR-008 | ReviewApproval | All injected cursor/overlay objects carry `DINOForge_` prefix; no unnamed injected objects (grep `new GameObject` in TcCursorApplicator + TcUiSpritePass) | Implementing → Validated |
 | EPIC-027-NFR-011 | SchemaValidation | `PackCompiler validate` rejects a manifest with `..` or absolute-path asset references in `asset_replacements.ui` | Implementing → Validated |
 | EPIC-027-NFR-013 | CiOutput | `LogOutput.log` grep: no `TypeLoadException` after clean launch with Strategy A Harmony Prefix active | Implementing → Validated |
 | EPIC-027-NFR-014 | TestResult | `docs/test-results/SW-007/TcSpriteLoaderTests.xml` — missing/failed sprite asset falls back to vanilla, warning logged, no crash | Implementing → Validated |
-| EPIC-027-NFR-015 | CodeReview | Overlay Image components in `TcUiSpritePass` have `raycastTarget = false`; EventSystem guard present before any GraphicRaycaster add | Implementing → Validated |
+| EPIC-027-NFR-015 | ReviewApproval | Overlay Image components in `TcUiSpritePass` have `raycastTarget = false`; EventSystem guard present before any GraphicRaycaster add | Implementing → Validated |
 | EPIC-027-NFR-020 | ManualAttestation | Full play session (cross-reference with FR-013 receipt): no native medieval 2D art visible with TC active (judge receipt per mod) | Implementing → Validated |
 | SW-007 | ManualAttestation | `dino-sprite-key-map.yaml` published in `docs/reference/`; Strategy A intercepts at least one Addressables key (log confirmation + receipt) | Implementing → Validated |
 | SW-007 | ManualAttestation | Sprite cache invalidation verified on HotReload signal (hot-reload + re-scan shows updated sprite, no crash) | Implementing → Validated |

--- a/docs/specs/v0.27.0/loading-screen-takeover.md
+++ b/docs/specs/v0.27.0/loading-screen-takeover.md
@@ -141,10 +141,10 @@ in the scene hierarchy.
 | EPIC-027-NFR-004 | TestResult | Memory snapshot before/after open/close cycles shows no monotonic growth; recorded in `docs/test-results/SW-004/MemorySnapshot.txt` | Implementing → Validated |
 | EPIC-027-NFR-005 | CiOutput | CI build log (Runtime csproj TFM is `netstandard2.0`; no direct TMP/Addressables compile refs) | Implementing → Validated |
 | EPIC-027-NFR-006 | ManualAttestation | Bundles built with Unity 2021.3.45f2 load without silent failure under BepInEx 5.4.x (log confirmation) | Implementing → Validated |
-| EPIC-027-NFR-008 | CodeReview | All injected GameObjects carry `DINOForge_` prefix (grep of `new GameObject` in LoadingScreenController) | Implementing → Validated |
+| EPIC-027-NFR-008 | ReviewApproval | All injected GameObjects carry `DINOForge_` prefix (grep of `new GameObject` in LoadingScreenController) | Implementing → Validated |
 | EPIC-027-NFR-013 | CiOutput | `LogOutput.log` grep: no `TypeLoadException` after clean launch | Implementing → Validated |
 | EPIC-027-NFR-014 | TestResult | `docs/test-results/SW-004/ThemeScannerTests.xml` — missing-asset test: default background renders, warning logged, no crash | Implementing → Validated |
-| EPIC-027-NFR-015 | CodeReview | `LoadingScreenController` canvas has `raycastTarget = false` on overlaid images; `EventSystem.current != null` guard before `GraphicRaycaster.AddComponent` | Implementing → Validated |
+| EPIC-027-NFR-015 | ReviewApproval | `LoadingScreenController` canvas has `raycastTarget = false` on overlaid images; `EventSystem.current != null` guard before `GraphicRaycaster.AddComponent` | Implementing → Validated |
 | SW-004 | SchemaValidation | `PackCompiler validate` rejects `loading_screen:` on `type: content` pack fixture | Implementing → Validated |
 | SW-004 | TestResult | `docs/test-results/SW-004/LoadingScreenConfigValidationTests.xml` | Implementing → Validated |
 | SW-004 | ManualAttestation | Canvas destroyed after fade-out (no `DINOForge_LoadingScreen` in hierarchy after MainMenu loads — log/screenshot confirmation) | Implementing → Validated |

--- a/docs/specs/v0.27.0/mod-brand-identity.md
+++ b/docs/specs/v0.27.0/mod-brand-identity.md
@@ -139,9 +139,9 @@ ThemeEngine (SW-006) can apply them. SW-006 must land in the same sprint.
 | EPIC-027-FR-010 | ManualAttestation | `docs/proof/judge-receipts/SW-005-brand-sw.md` + `SW-005-brand-modern.md` (SW menu: deep-space bg, gold title, Republic palette; Modern: satellite bg, stencil title, amber palette — no vanilla DINO art visible) | Implementing → Validated |
 | EPIC-027-NFR-005 | CiOutput | CI build log (Runtime csproj `netstandard2.0`; no direct TMPro compile refs in identity wiring) | Implementing → Validated |
 | EPIC-027-NFR-006 | ManualAttestation | TMP font bundles built with Unity 2021.3.45f2 load without silent failure under BepInEx 5.4.x (log confirmation) | Implementing → Validated |
-| EPIC-027-NFR-007 | CodeReview | No Harmony patch targets DINO ECS/UI types in SW-005 scope (grep of `[HarmonyPatch` in identity files) | Implementing → Validated |
-| EPIC-027-NFR-008 | CodeReview | Logo/overlay GameObject named `DINOForge_ModLogo`; no unnamed injected objects (grep `new GameObject` in MainMenuReskinner for the logo path) | Implementing → Validated |
-| EPIC-027-NFR-015 | CodeReview | `DINOForge_ModLogo` Image has `raycastTarget = false`; EventSystem guard precedes any GraphicRaycaster add (Pattern #235) | Implementing → Validated |
+| EPIC-027-NFR-007 | ReviewApproval | No Harmony patch targets DINO ECS/UI types in SW-005 scope (grep of `[HarmonyPatch` in identity files) | Implementing → Validated |
+| EPIC-027-NFR-008 | ReviewApproval | Logo/overlay GameObject named `DINOForge_ModLogo`; no unnamed injected objects (grep `new GameObject` in MainMenuReskinner for the logo path) | Implementing → Validated |
+| EPIC-027-NFR-015 | ReviewApproval | `DINOForge_ModLogo` Image has `raycastTarget = false`; EventSystem guard precedes any GraphicRaycaster add (Pattern #235) | Implementing → Validated |
 | EPIC-027-NFR-018 | CiOutput | New user-visible strings in SW-005 resolve through locale layer; non-English locale shows translated labels (i18n CI check) | Implementing → Validated |
 | EPIC-027-NFR-020 | ManualAttestation | Full play session judge receipt per mod shows no native medieval 2D art on main menu (cross-references SW-005-brand receipts above) | Implementing → Validated |
 | EPIC-027-NFR-021 | ManualAttestation | Faction emblems (Republic + CIS; Alliance + Enemy) visible in-game per mod; unit portraits present on spawnable units (screenshot per mod) | Implementing → Validated |

--- a/docs/specs/v0.27.0/native-mods-page-visible.md
+++ b/docs/specs/v0.27.0/native-mods-page-visible.md
@@ -127,10 +127,10 @@ reports both Active,
 | EPIC-027-FR-020 | ManualAttestation | Toggling a pack updates its active badge; `dinoforge status` reflects the toggle after relaunch (log + status output) | Implementing → Validated |
 | EPIC-027-NFR-001 | ManualAttestation | Timed Mods page open ≤ 500 ms on 60 FPS host (F9 overlay timestamp or log timing) | Implementing → Validated |
 | EPIC-027-NFR-004 | TestResult | Open/close cycles show no monotonic GameObject/memory growth in snapshot (docs/test-results/SW-001/MemorySnapshot.txt) | Implementing → Validated |
-| EPIC-027-NFR-007 | CodeReview | No `[HarmonyPatch` attribute targets DINO UI type in SW-001 scope (grep in NativeMenuInjector + NativeModsPage) | Implementing → Validated |
-| EPIC-027-NFR-008 | CodeReview | Page GameObject named `DINOForge_ModsPage`; no unnamed injected objects (grep `new GameObject` in NativeModsPage.BuildUI) | Implementing → Validated |
-| EPIC-027-NFR-009 | CodeReview | No `Process.Start` / URL-open path consumes unvalidated pack data (grep in NativeModsPage + ContextualModMenuHost) | Implementing → Validated |
-| EPIC-027-NFR-015 | CodeReview | Mods button injection has `raycastTarget = false` on any overlay Image; EventSystem guard present (Pattern #235) | Implementing → Validated |
+| EPIC-027-NFR-007 | ReviewApproval | No `[HarmonyPatch` attribute targets DINO UI type in SW-001 scope (grep in NativeMenuInjector + NativeModsPage) | Implementing → Validated |
+| EPIC-027-NFR-008 | ReviewApproval | Page GameObject named `DINOForge_ModsPage`; no unnamed injected objects (grep `new GameObject` in NativeModsPage.BuildUI) | Implementing → Validated |
+| EPIC-027-NFR-009 | ReviewApproval | No `Process.Start` / URL-open path consumes unvalidated pack data (grep in NativeModsPage + ContextualModMenuHost) | Implementing → Validated |
+| EPIC-027-NFR-015 | ReviewApproval | Mods button injection has `raycastTarget = false` on any overlay Image; EventSystem guard present (Pattern #235) | Implementing → Validated |
 | EPIC-027-NFR-016 | ManualAttestation | Mods page hover/layout matches adjacent native buttons (verified against live `dinoforge ui-tree` dump) | Implementing → Validated |
 | EPIC-027-NFR-017 | ManualAttestation | Escape closes Mods page; keyboard navigation moves focus across entries (in-game confirmation) | Implementing → Validated |
 | EPIC-027-NFR-018 | CiOutput | New UI strings resolve through locale layer; non-English locale shows translated labels (i18n CI check) | Implementing → Validated |

--- a/docs/specs/v0.27.0/requirements.md
+++ b/docs/specs/v0.27.0/requirements.md
@@ -35,6 +35,9 @@ description. Evidence tables live in the individual story files.
 | EPIC-027-FR-018 | SW-011 | Aerial units spawn, pathfind over all terrain, attack ground and air targets for both mods. |
 | EPIC-027-FR-019 | SW-012 | Audio takeover: menu music and gameplay ambient music replaced for both mods; crossfade works without hard cut. |
 | EPIC-027-FR-020 | SW-001, SW-008 | Toggling a pack updates its active badge; `dinoforge status` reflects the toggle after relaunch. |
+| EPIC-027-FR-021 | SW-014 | `steam_appid.txt` (=`1272320`) is auto-provisioned beside the game exe on deploy/launch so DINO does not self-relaunch via Steam and kill the injected process; BepInEx/MODS/F9-F10 survive the transition. |
+| EPIC-027-FR-022 | SW-001, SW-014 | Clicking the native Mods button opens a native-styled quick MODS panel (default click) listing installed packs; a "Browse all" affordance escalates to the full mod browser. |
+| EPIC-027-FR-023 | SW-008, SW-014 | Pack roster is cut to a deterministic focus set: exactly one total-conversion pack is selected deterministically at load; non-focus packs are shipped `.disabled`; `warfare-naval` content pack present. |
 
 ---
 
@@ -64,3 +67,6 @@ description. Evidence tables live in the individual story files.
 | EPIC-027-NFR-020 | SW-005, SW-007, SW-008 | Visual | Full play session with TC active shows no vanilla DINO medieval 2D art (judge receipt per mod). |
 | EPIC-027-NFR-021 | SW-005, SW-008 | Visual | Faction emblems (Republic + CIS; Alliance + Enemy) and unit portraits visible in-game for both mods. |
 | EPIC-027-NFR-022 | SW-008, SW-012 | Legal | Asset licensing manifest complete: every shipped audio, image, and 3D asset is documented as original composition or CC0-licensed; `LICENSE-audio.md` / `LICENSE-assets.md` present in each pack root. |
+| EPIC-027-NFR-023 | SW-011, SW-014 | Stability | Aviation/aerial ECS systems use manual `EntityQuery` iteration loops, not codegen-dependent `Entities.ForEach`; no Burst/codegen TypeLoadException under BepInEx Mono at runtime. |
+| EPIC-027-NFR-024 | SW-014 | Stability | Runtime update-check JSON serialization uses the static `JsonConvert.SerializeObject` overload (no instance/MethodNotFound reflection failure) under the BepInEx-bundled Newtonsoft.Json. |
+| EPIC-027-NFR-025 | SW-003, SW-008, SW-014 | Asset Gate | Real-mesh bundle conversion is tracked against the declared roster: at least 14/36 Star Wars bundles wire real meshes (not primitives) and the conversion pipeline (`convert_real_models.py`) is reproducible; remaining stubs are logged, not silently primitive. |

--- a/docs/specs/v0.27.0/runtime-survival-reconcile.md
+++ b/docs/specs/v0.27.0/runtime-survival-reconcile.md
@@ -1,0 +1,135 @@
+# SW-014: Runtime Survival & v0.27.0 Reconcile
+
+**Status**: Shipped
+**AgilePlus WP State**: done
+**Sequence**: 14
+**Date**: 2026-05-30
+**Author**: DINOForge Agents
+**Epic**: [EPIC-027 — True Full-Conversion Experience](../v0.27.0-full-conversion-epic.md)
+**AgilePlus Feature Slug**: epic-027-full-conversion
+**Sprint**: 1 — Foundation (survival hardening) + cross-sprint reconcile
+**Story Points**: 13
+**Priority**: P0 — Release blocker (without process survival, nothing downstream is observable)
+**File Scope**:
+  - `scripts/game/write-dump.ps1`
+  - `src/Tools/Cli/Commands/DeployCommand.cs`
+  - `src/Runtime/UI/NativeMainMenuModMenu.cs`
+  - `src/Runtime/UI/NativeMenuInjector.cs`
+  - `src/Domains/Warfare/Aviation/`
+  - `src/Runtime/UpdateCheck/UpdateChecker.cs`
+  - `packs/warfare-modern/pack.yaml`
+  - `packs/warfare-naval/`
+**Depends On**: [SW-001, SW-003, SW-011]
+**Requirements**: EPIC-027-FR-021, EPIC-027-FR-022, EPIC-027-FR-023, EPIC-027-NFR-002, EPIC-027-NFR-005, EPIC-027-NFR-006, EPIC-027-NFR-013, EPIC-027-NFR-023, EPIC-027-NFR-024, EPIC-027-NFR-025
+
+---
+
+## User Story
+
+As a **mod developer**, I want the injected DINOForge process to survive DINO's startup
+transitions and the runtime to load without codegen/serialization failures, so that every
+other EPIC-027 feature (Mods page, reskin, aerial content) is actually reachable and
+observable in-game instead of dying silently before the first frame.
+
+## Background
+
+Six iterations (iter-144 through iter-149) chased a "no BepInEx / no MODS button / dead
+F9-F10" symptom that looked like a dormant plugin or a native wedge. The definitive root
+cause (`project_dino_steam_selfrelaunch_root_cause.md`, iter-149) is that DINO **self-relaunches
+via Steam** when launched directly without `steam_appid.txt`, killing the injected process.
+The fix is to auto-provision `steam_appid.txt` = `1272320` beside the exe on every deploy/launch
+(Steam Verify deletes it, so it must be re-created on deploy).
+
+Once the process survived, two more runtime load-failures surfaced:
+- Aviation/aerial ECS systems used `Entities.ForEach`, which depends on Burst/Roslyn codegen
+  that is unavailable under BepInEx Mono — raising TypeLoadException at load.
+- The update-check path called an instance `JsonConvert.SerializeObject` overload that does
+  not exist on the BepInEx-bundled Newtonsoft.Json (MethodNotFound).
+
+This story also reconciles the shipped roster and UX deltas: the native Mods button now opens
+a **quick MODS panel** by default (with Browse-all escalation), and the pack roster was cut to
+a deterministic focus set (non-focus packs `.disabled`, `warfare-naval` added).
+
+## Acceptance Criteria
+
+### Scenario 1 — Process survives launch (steam_appid)
+
+**Given** the game is deployed and launched directly (not via the Steam client),
+**When** DINO completes its startup transition,
+**Then** `steam_appid.txt` (=`1272320`) exists beside the exe, the process is NOT replaced by a
+Steam-spawned child, and BepInEx + the MODS button + F9/F10 are all live.
+
+### Scenario 2 — Runtime loads with no codegen/serialization failure
+
+**Given** the runtime DLL deployed under BepInEx Mono,
+**When** the plugin loads and the aerial domain + update-check run,
+**Then** `LogOutput.log` contains no `TypeLoadException` and no `MethodNotFound` for
+`JsonConvert.SerializeObject`; aerial systems iterate via manual `EntityQuery` loops.
+
+### Scenario 3 — Quick MODS panel is the default click
+
+**Given** the native Mods button is visible,
+**When** the player clicks it,
+**Then** a native-styled quick MODS panel opens listing installed packs, with a visible
+"Browse all" affordance that opens the full mod browser.
+
+### Scenario 4 — Deterministic roster
+
+**Given** the shipped pack set,
+**When** the runtime selects a total-conversion pack,
+**Then** exactly one TC pack is chosen deterministically, non-focus packs are present as
+`.disabled`, and `warfare-naval` is loadable.
+
+## Functional Requirements
+
+| ID | Requirement |
+|----|-------------|
+| F-01 | Deploy/launch step writes `steam_appid.txt`=`1272320` beside the exe if absent. |
+| F-02 | Quick MODS panel renders as default Mods-button action; Browse-all opens full browser. |
+| F-03 | Deterministic single-TC selection; non-focus packs shipped `.disabled`. |
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|----|-------------|
+| N-01 | Aerial ECS systems use manual `EntityQuery` loops, not `Entities.ForEach`. |
+| N-02 | Update-check uses static `JsonConvert.SerializeObject` overload. |
+| N-03 | No `TypeLoadException` / `MethodNotFound` in `LogOutput.log` after clean launch. |
+
+## Engine Quirks / Dependencies
+
+- DINO self-relaunches via Steam without `steam_appid.txt`; check process parentage across
+  startup transitions, not just `MainWindowTitle` (iter-149 lesson).
+- `Entities.ForEach` requires source-generators absent under BepInEx Mono — manual
+  `EntityManager` / `EntityQuery` iteration only (CLAUDE.md ECS facts).
+- BepInEx ships its own Newtonsoft.Json; prefer the static serialization overloads.
+
+## Definition of Done
+
+- [x] `steam_appid.txt` auto-provisioned; injected process survives launch (live proof).
+- [x] Aviation systems converted to manual `EntityQuery` loops; no TypeLoadException.
+- [x] Update-check Newtonsoft MethodNotFound fixed (static overload).
+- [x] Quick MODS panel is the default Mods-button click; Browse-all escalates.
+- [x] Roster cut to deterministic focus set; `warfare-naval` added.
+- [x] CHANGELOG.md updated for v0.27.0.
+
+## Evidence Requirements
+
+| Requirement ID | Evidence Type | Artifact Path Pattern | Transition Gate |
+|----------------|---------------|-----------------------|-----------------|
+| EPIC-027-FR-021 | ManualAttestation | `docs/screenshots/mods-button-FIXED-steamappid-20260529.png` + `docs/sessions/dino-steam-selfrelaunch-fix-20260529.md` (process survives; BepInEx/MODS/F9-F10 live) | Implementing -> Validated |
+| EPIC-027-FR-022 | ManualAttestation | `docs/screenshots/fixbranch-ab8c6074-live.png` (quick MODS panel opens on default click; Browse-all visible) | Implementing -> Validated |
+| EPIC-027-FR-023 | ReviewApproval | `packs/*.disabled/` present + single deterministic TC selection + `packs/warfare-naval/` (commit d77040d2 / PackCut #4) | Implementing -> Validated |
+| EPIC-027-NFR-023 | ReviewApproval | Aviation systems use manual `EntityQuery` loops, not `Entities.ForEach` (commit 7a9dea82) | Implementing -> Validated |
+| EPIC-027-NFR-024 | ReviewApproval | Update-check uses static `JsonConvert.SerializeObject` (commit 72da648d) | Implementing -> Validated |
+| EPIC-027-NFR-025 | TestResult | `convert_real_models.py` output; >=14/36 SW bundles wire real meshes (commit 884908b2 / RealMesh #5) | Implementing -> Validated |
+| EPIC-027-NFR-013 | ManualAttestation | `LogOutput.log` shows no TypeLoadException after clean launch (iter-149 session log) | Implementing -> Validated |
+| SW-014 | ReviewApproval | PR URL (auto-detected from WorkPackage.pr_url) | Validated -> Shipped |
+| SW-014 | CiOutput | GitHub Actions run URL (dotnet build/test green) | Implementing -> Validated |
+
+## Related
+
+- `docs/sessions/dino-steam-selfrelaunch-fix-20260529.md`
+- `project_dino_steam_selfrelaunch_root_cause.md` (memory)
+- SW-001 (Native Mods Page), SW-003 (Real Asset Bundles), SW-011 (Aerial Combat)
+- Pattern #530 (MSBuild deploy silent no-op — verify deploy by hash/process, not exit 0)


### PR DESCRIPTION
## **User description**
Adds requirements/traceability/story coverage for the EPIC-027 features that
actually shipped this session (steam_appid survival, native quick MODS panel,
deterministic pack-cut roster, Aviation codegen fix, Newtonsoft static-overload
fix, real-mesh bundles), and brings the specs into AgilePlus conformance.

- requirements.md: +FR-021 (steam_appid process survival), +FR-022 (quick MODS
  panel), +FR-023 (deterministic single-TC roster); +NFR-023 (manual EntityQuery,
  no codegen Entities.ForEach), +NFR-024 (static JsonConvert.SerializeObject),
  +NFR-025 (real-mesh bundle conversion gate). 23 FR + 25 NFR total.
- New story SW-014 (runtime-survival-reconcile.md): AgilePlus WorkPackage
  sequence=14, state=done, file_scope, acceptance_criteria, Depends On, full
  Evidence Requirements table (valid EvidenceType variants only).
- traceability-matrix.md: added EPIC-027 FR traceability table (FR-001..023) +
  NFR-023..025 rows + SW-001..014 AgilePlus story link. Verified 0 orphans, 0
  dangling refs across catalog/matrix/stories.
- epic spec: state Proposed -> Implementing; child-story table + sprint totals
  updated for SW-014 (144 excl / 157 incl stretch); agileplus_spec_hash recomputed
  (SHA256 18D1CBD2..D8ACFC9); Mermaid traceability/dependency diagram added.
- Conformance fix: invalid CodeReview evidence type -> ReviewApproval in 5 stories
  (EvidenceType enum has no CodeReview variant per agileplus-domain governance.rs).
- CHANGELOG: EPIC-027 spec/traceability reconcile entry.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and spec metadata only; no runtime, build, or deployment behavior changes.
> 
> **Overview**
> **Documentation-only** update that aligns EPIC-027 specs and AgilePlus artifacts with work already shipped for v0.27.0 (runtime survival, MODS UX, pack roster, stability NFRs).
> 
> `requirements.md` gains **FR-021–023** (steam_appid process survival, default quick MODS panel + Browse-all, deterministic single-TC roster with `warfare-naval`) and **NFR-023–025** (manual Aviation `EntityQuery`, static Newtonsoft serialization, real-mesh bundle gate). A new **SW-014** story documents runtime survival and reconcile with acceptance criteria, file scope, and evidence tables.
> 
> **EPIC-027** moves to **Implementing**, sprint totals include SW-014 (144/157 points), **`agileplus_spec_hash`** is refreshed, and a **Mermaid** epic→story→requirement diagram is added. **`traceability-matrix.md`** now maps FR-001–023 and extended NFR rows to owning stories; **`CHANGELOG`** records the reconcile.
> 
> Across five existing stories, invalid **`CodeReview`** evidence types are renamed to **`ReviewApproval`** so tables match the AgilePlus `EvidenceType` enum.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd37f789bc5402141729f4c3bfe3523ec92ecdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Reconcile EPIC-027 specs with the shipped v0.27.0 work**

### What Changed
- Added the missing v0.27.0 requirements and traceability entries for steam app ID survival, the quick MODS panel, deterministic pack selection, the Aviation runtime fix, the Newtonsoft serialization fix, and real-mesh bundle tracking
- Added a new SW-014 story that describes the launch-survival and runtime-reconciliation work, including its acceptance criteria and evidence requirements
- Updated the epic overview, README, and traceability matrix to match the shipped story set and remove mismatched evidence labels
- Recorded the EPIC-027 spec and traceability updates in the changelog

### Impact
`✅ Clearer v0.27.0 release documentation`
`✅ Complete EPIC-027 requirement coverage`
`✅ Fewer traceability mismatches during review`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated EPIC-027 v0.27.0 specification and traceability documentation.
  * Added comprehensive requirements catalog with new functional and non-functional requirements.
  * Created traceability matrix and dependency diagrams for v0.27.0.
  * Added new work package specification: SW-014 Runtime Survival & v0.27.0 Reconcile.

* **Changed**
  * Updated EPIC-027 v0.27.0 status from Proposed to Implementing.
  * Corrected evidence requirement classifications across specification documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->