### PR TITLE
feat(tooling): add game_dump_ui_tree alias and ui-tree census doc

### DIFF
--- a/docs/sessions/ui-tree-census-20260601.md
+++ b/docs/sessions/ui-tree-census-20260601.md
@@ -1,0 +1,55 @@
+# UI Tree Census — 2026-06-01
+
+Branch: `feat/uicensus-20260601`  
+Environment: MCP server at `http://127.0.0.1:8765`  
+Capture status: **partial (no live game pipe connection at capture time)**
+
+## Capture notes
+
+- Added MCP tool: `game_dump_ui_tree` in `src/Tools/DinoforgeMcp/dinoforge_mcp/server.py`.
+- Added CLI wiring for `dump-ui-tree` (alias of `ui-tree`) in `src/Tools/GameControlCli/Program.cs` with `includeCursor` control.
+- Runtime snapshot already emits `IsThemed`, `RenderPath`, `Visual` and a native cursor node (`RenderPath = native-cursor`) from `UiTreeSnapshotBuilder`.
+- Live call attempt via MCP/CLI failed with `Failed to connect to pipe 'dinoforge-game-bridge'`, so this matrix is a **static census scaffold** plus prior runtime dump-field coverage, not a fully materialized runtime dump.
+
+## Matrix (static + existing snapshot coverage)
+
+| Surface | Element | Type | Render-path | State | Fix-needed | Notes |
+|---|---|---|---|---|---|---|
+| main menu | root background canvas | Canvas | canvas | native | yes | Verify full theming pass for top-level menu sprites |
+| main menu | logo/title | Image | Image-sprite | native | yes | DINOForge icon/branding often bypasses theme swap |
+| main menu | menu option button | Button | Image-sprite | themed/partial | maybe | Button style fields are captured; requires click-path verification |
+| main menu / subpages | primary label text | TMP_Text | TMP-text | themed/partial | maybe | Many labels use TMP/TextMeshPro with dynamic font fallback |
+| MODS page | tab button | Button | Image-sprite | themed/partial | maybe | MODS button hook exists (`DINOForge_ModsButton`) but adjacent siblings may remain native |
+| MODS page | mod row icon | Image | Image-sprite | native | yes | Icon atlas coverage likely inconsistent |
+| F10 menu | section headers | TMP_Text | TMP-text | native | yes | Needs audit once game is running |
+| F10 menu | list row background | Image | Image-sprite | native | yes | Common whack-a-mole surface from runtime themes |
+| loading screen | background image | Image | Image-sprite | native | yes | Backgrounds/cutscenes often loaded after theme init |
+| loading screen | loading caption | TMP_Text | TMP-text | native | yes | Runtime font/theme timing risk at transition boundaries |
+| build-panel | card icon | Image | Image-sprite | native | yes | Multiple cards are image-first and not all theme-swapped |
+| build-panel | card title text | TMP_Text | TMP-text | native | yes | TMP font pass should be audited globally |
+| HUD | resource icon | Image | Image-sprite | native | yes | HUD icon strips frequently remain native |
+| HUD | action button | Button | Image-sprite | themed/partial | maybe | Button background + child label parity check needed |
+| HUD | status value | TMP_Text | TMP-text | native | yes | Numeric/status text may remain native in some views |
+| enemy-preview | portrait frame | Image | Image-sprite | native | yes | Portrait and frame textures often split by runtime path |
+| enemy-preview | faction flag | Image | Image-sprite | native | yes | Faction flag texture surface currently not consistently themed |
+| enemy-preview | faction name | TMP_Text | TMP-text | native | yes | Requires unified label theming |
+| cursor | hardware pointer | Cursor | native-cursor | native | yes | Always captured as `native-cursor`, currently not themed |
+| cursor | click hotspot helper | Image | Image-sprite | native | no | None currently identified in live dump |
+| ECS-mesh overlay | mesh-backed glyph layer | ECS-mesh | ECS-mesh | native | no | Render-path retained for future mesh-based surfaces |
+
+## Priority list of likely native surfaces (top offenders)
+
+- Cursor (`native-cursor`)  
+- Main menu background/title surfaces (`Canvas` + `Image` blocks)  
+- HUD resource/action icons (`Image`)  
+- Faction flags (`Image`)  
+- MODS page row/tab surfaces (`Image`/`Button`)  
+- Loading captions and headers (`TMP_Text`)  
+- Enemy preview portrait/flag region (`Image`)  
+
+## Next action for live census
+
+- Re-run:
+  - `python tools/mcp_client.py call game_dump_ui_tree --selector <surface> --include-cursor true` (or use CLI):
+  - `dotnet run --project src/Tools/GameControlCli -- dump-ui-tree`
+- Export and replace this static table with the full live rows for all listed surfaces.

--- a/src/Tools/DinoforgeMcp/dinoforge_mcp/server.py
+++ b/src/Tools/DinoforgeMcp/dinoforge_mcp/server.py
@@ -538,9 +538,28 @@ async def game_ui_tree(ctx: Context, selector: str | None = None, pipe_name: str
         selector: Optional CSS-like selector to filter results.
         pipe_name: Optional named pipe name for multi-instance support (defaults to "dinoforge-game-bridge").
     """
+    return await game_dump_ui_tree(ctx, selector=selector, pipe_name=pipe_name)
+
+
+@mcp.tool()
+async def game_dump_ui_tree(
+    ctx: Context,
+    selector: str | None = None,
+    include_cursor: bool = True,
+    pipe_name: str | None = None,
+) -> dict:
+    """
+    Dump a full runtime UI census snapshot with visual metadata and themed/native flags.
+
+    Args:
+        selector: Optional selector string to filter results.
+        include_cursor: Whether to include hardware cursor metadata.
+        pipe_name: Optional named pipe name for multi-instance support (defaults to "dinoforge-game-bridge").
+    """
     args = ["ui-tree"]
     if selector:
         args.append(selector)
+    args.append(f"includeCursor={str(include_cursor).lower()}")
     return _run_game_cli(*args, pipe_name=pipe_name)
 
 

--- a/src/Tools/GameControlCli/Program.cs
+++ b/src/Tools/GameControlCli/Program.cs
@@ -91,7 +91,8 @@ public static class Program
             "toggle-ui" => await HandleToggleUiCommand(remainingArgs.Skip(1).FirstOrDefault()).ConfigureAwait(false),
             "scan-scene" => await HandleScanSceneCommand(remainingArgs.Skip(1).FirstOrDefault()).ConfigureAwait(false),
             "invoke-method" => await HandleInvokeMethodCommand(remainingArgs.Skip(1).ToArray()).ConfigureAwait(false),
-            "ui-tree" => await HandleUiTreeCommand(remainingArgs.Skip(1).FirstOrDefault()).ConfigureAwait(false),
+            "ui-tree" => await HandleUiTreeCommand(remainingArgs.Skip(1).ToArray()).ConfigureAwait(false),
+            "dump-ui-tree" => await HandleUiTreeCommand(remainingArgs.Skip(1).ToArray()).ConfigureAwait(false),
             "ui-pointer" => await HandleUiPointerCommand(remainingArgs.Skip(1).ToArray()).ConfigureAwait(false),
             "navigate-to-gameplay" => await HandleNavigateToGameplayCommand(remainingArgs.Skip(1).ToArray()).ConfigureAwait(false),
             "demo" => await HandleDemoCommand().ConfigureAwait(false),
@@ -211,7 +212,8 @@ public static class Program
         AnsiConsole.MarkupLine("  toggle-ui <target>    - Toggle DINOForge UI: modmenu (F10) or debug (F9)");
         AnsiConsole.MarkupLine("  scan-scene <filter>   - Dump active MonoBehaviours + their void() methods");
         AnsiConsole.MarkupLine("  invoke-method <target> <method> - Call a void() method on matching MB");
-        AnsiConsole.MarkupLine("  ui-tree <selector>    - Snapshot the live Unity UI hierarchy (Playwright-style DOM)");
+        AnsiConsole.MarkupLine("  ui-tree [selector] [includeCursor=true|false] - Snapshot the live Unity UI hierarchy (Playwright-style DOM)");
+        AnsiConsole.MarkupLine("  dump-ui-tree [selector] [includeCursor=true|false] - Alias for ui-tree with full visual metadata");
         AnsiConsole.MarkupLine("  demo             - Full end-to-end demo: menu → mods → F9/F10 → save → gameplay");
         AnsiConsole.MarkupLine("  --help, -h       - Show this help");
         AnsiConsole.MarkupLine("");
@@ -734,19 +736,63 @@ public static class Program
         }
     }
 
-    private static async Task<int> HandleUiTreeCommand(string? selector)
+    private static async Task<int> HandleUiTreeCommand(string[] args)
     {
+        string? selector = null;
+        bool includeCursor = true;
+
+        foreach (string arg in args)
+        {
+            if (arg is null)
+                continue;
+
+            if (arg.StartsWith("includeCursor=", StringComparison.OrdinalIgnoreCase))
+            {
+                if (bool.TryParse(arg.Substring("includeCursor=".Length), out bool parsed))
+                    includeCursor = parsed;
+                continue;
+            }
+
+            if (arg.StartsWith("--include-cursor=", StringComparison.OrdinalIgnoreCase))
+            {
+                if (bool.TryParse(arg.Substring("--include-cursor=".Length), out bool parsed))
+                    includeCursor = parsed;
+                continue;
+            }
+
+            if (arg.Equals("--no-cursor", StringComparison.OrdinalIgnoreCase) ||
+                arg.Equals("--no-include-cursor", StringComparison.OrdinalIgnoreCase) ||
+                arg.Equals("--include-cursor=false", StringComparison.OrdinalIgnoreCase))
+            {
+                includeCursor = false;
+                continue;
+            }
+
+            if (selector == null)
+                selector = arg;
+        }
+
         using var client = new GameClient(CreateClientOptions());
         try
         {
             await client.ConnectAsync().ConfigureAwait(false);
-            AnsiConsole.MarkupLine($"[cyan]Capturing UI tree{(selector != null ? $" (selector: {selector})" : "")}...[/]");
-            UiTreeResult result = await client.GetUiTreeAsync(selector).ConfigureAwait(false);
+            if (!JsonOutput)
+                AnsiConsole.MarkupLine($"[cyan]Capturing UI tree{(selector != null ? $" (selector: {selector})" : "")} (includeCursor={includeCursor})[/]");
+            UiTreeResult result = await client.GetUiTreeAsync(selector, includeCursor).ConfigureAwait(false);
             if (!result.Success)
             {
-                AnsiConsole.MarkupLine($"[red]✗[/] {Markup.Escape(result.Message)}");
+                if (JsonOutput)
+                    Console.WriteLine(System.Text.Json.JsonSerializer.Serialize(new { success = false, error = result.Message }, GameControlCliJsonOptions.Indented));
+                else
+                    AnsiConsole.MarkupLine($"[red]✗[/] {Markup.Escape(result.Message)}");
                 client.Disconnect();
                 return 1;
+            }
+            if (JsonOutput)
+            {
+                Console.WriteLine(System.Text.Json.JsonSerializer.Serialize(result, GameControlCliJsonOptions.Indented));
+                client.Disconnect();
+                return 0;
             }
             AnsiConsole.MarkupLine($"[green]✓[/] {result.NodeCount} nodes  ({result.GeneratedAtUtc})");
             PrintUiNode(result.Root, 0);


### PR DESCRIPTION
## **User description**
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Tooling and documentation only; no game runtime or auth changes. Note: CLI now calls `GetUiTreeAsync(selector, includeCursor)`—ensure the bridge client overload exists or the build may fail.
> 
> **Overview**
> Adds **runtime UI census** tooling and a **static theming audit scaffold** for agents and humans.
> 
> **MCP:** New `game_dump_ui_tree` tool (optional `selector`, `include_cursor`, `pipe_name`) forwards to GameControlCli with `includeCursor=…`. Existing `game_ui_tree` now delegates to the same path so both tools share behavior.
> 
> **CLI:** `dump-ui-tree` is an alias of `ui-tree`. `HandleUiTreeCommand` parses multiple args (selector plus `includeCursor=`, `--include-cursor=`, or `--no-cursor` flags), passes `includeCursor` into the bridge client, and when `--format=json` is set emits the full `UiTreeResult` JSON (including failures) instead of only human-readable tree output. Help text documents the new flags.
> 
> **Docs:** `docs/sessions/ui-tree-census-20260601.md` records capture status (partial without live pipe), a surface/element matrix of likely native vs themed UI, priority offenders, and how to re-run live dumps via MCP or CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a68e2b2a793d0d0c2bd8ac34af992eb133767aa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


___

## **CodeAnt-AI Description**
**Add a UI tree dump alias, cursor toggle, and a census note for runtime UI audits**

### What Changed
- `ui-tree` now accepts a selector plus cursor-inclusion options, and `dump-ui-tree` was added as an alias for the same snapshot output.
- UI tree capture can now include or exclude hardware cursor data, and JSON output returns the full result, including failures.
- The MCP tool `game_dump_ui_tree` was added and `game_ui_tree` now uses the same path so both tools return the same UI snapshot behavior.
- A new session note records the UI census findings, likely native surfaces, and how to re-run a live dump.

### Impact
`✅ Easier runtime UI audits`
`✅ Clearer UI snapshot output for scripts`
`✅ Faster re-running of live UI dumps`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
