### PR TITLE
feat(packs): absorb dinoforge-packs into Dino (community-contributions/)

### DIFF
--- a/docs/dinoforge-packs-absorption.md
+++ b/docs/dinoforge-packs-absorption.md
@@ -1,0 +1,96 @@
+# dinoforge-packs absorption — 2026-06-18
+
+This document records the absorption of `KooshaPari/dinoforge-packs` into
+`KooshaPari/Dino` per kilo audit #144 (PRESERVE → ABSORBED) and ADR-023 (app
+substrate placement).
+
+## What was absorbed
+
+| Source path (dinoforge-packs) | Destination (Dino) | Type | Status |
+|-------------------------------|---------------------|------|--------|
+| `example-balance/` | `packs/example-balance/` | New pack (not in Dino) | ✅ **ACTIVE** |
+| `warfare-starwars/` | `packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/` | Stale duplicate | ⚠️ **ID migration needed** |
+| `tests/smoke_test.go` | `tests/packs/dinoforge-packs_smoke_test.go` | Test | ✅ active |
+| `docs/{journeys,operations,sessions,worklogs}/` | `packs/community-contributions/dinoforge-packs-mirror/docs/` | Reference docs | ✅ preserved |
+| `AGENTS.md` | `docs/dinoforge-packs_AGENTS.md` | Governance | ✅ preserved |
+| `CLAUDE.md` | `docs/dinoforge-packs_CLAUDE.md` | Governance | ✅ preserved |
+| `FUNCTIONAL_REQUIREMENTS.md` | `docs/dinoforge-packs_FUNCTIONAL_REQUIREMENTS.md` | Spec | ✅ preserved |
+| `CHANGELOG.md` | `docs/dinoforge-packs_CHANGELOG.md` | History | ✅ preserved |
+| `LICENSE` | inherited (repo MIT) | License | ✅ preserved |
+| `README.md` | `packs/community-contributions/dinoforge-packs-mirror/README.md` | Doc | ✅ preserved |
+
+## ID divergence (the important part)
+
+The dinoforge-packs warfare-starwars manifest declares units with
+**legacy non-namespaced IDs**:
+
+```yaml
+# dinoforge-packs/warfare-starwars/manifest.yaml (legacy)
+units:
+  - clone-trooper
+  - arc-trooper
+  - b1-battle-droid
+  - droideka
+```
+
+These IDs **DO NOT EXIST** in the canonical Dino `packs/warfare-starwars/`
+pack. The canonical pack uses **namespaced faction_kind-prefixed IDs**:
+
+```yaml
+# Dino/packs/warfare-starwars/manifest.yaml (canonical)
+units:
+  - rep_clone_trooper
+  - rep_arc_trooper
+  - cis_b1_droid
+  - cis_droideka
+```
+
+### Why the divergence?
+
+DINOForge refactored to faction-namespaced unit IDs in v0.5.0 to support
+multi-faction coexistence in the same load order (legacy IDs collided when
+Republic and CIS units loaded together). The dinoforge-packs repo was
+frozen at v0.1.0 content and never received the v0.5.0 ID migration.
+
+### Migration path (open follow-up)
+
+1. Open PR remapping `units:`/`buildings:`/`weapons:`/`doctrines:` lists in
+   the mirrored manifest:
+   - `clone-trooper` → `rep_clone_trooper`
+   - `arc-trooper` → `rep_arc_trooper`
+   - `at-te` → `rep_atte_crew`
+   - `clone-gunship` → `rep_v19_torrent`
+   - `b1-battle-droid` → `cis_b1_droid`
+   - `b2-super-battle-droid` → `cis_b2_droid`
+   - `droideka` → `cis_droideka`
+   - `hailfire-droid` → `cis_hailfire_droid`
+   - `commando-droid` → `cis_commando_droid`
+   - `magna-guard` → `cis_magnaguard`
+2. Add `"<1.0.0"` upper bound to `framework_version`
+3. Replace faction `replaces_vanilla:` values to match canonical names
+4. Add `ui_theme:` block per canonical template
+5. After migration passes `go test ./tests/packs/...`, promote from
+   `community-contributions/` into `packs/warfare-starwars-republic-cis/`
+
+## Governance doc retention
+
+The absorbed `AGENTS.md` (74 lines) and `CLAUDE.md` (60 lines) are preserved
+verbatim as `docs/dinoforge-packs_AGENTS.md` and `docs/dinoforge-packs_CLAUDE.md`
+because they capture the original team's working agreements. They should be
+read alongside (not in place of) Dino's `AGENTS.md` and `CLAUDE.md`.
+
+## Source-of-truth reconciliation
+
+After absorption, the canonical pack definitions live in `KooshaPari/Dino`.
+The original `KooshaPari/dinoforge-packs` repo is marked archived (gh token
+lacks `delete_repo` scope; archive is the available action).
+
+## References
+
+- Kilo audit #144: `.kilo/audits/kooshapari-absorption-2026-06-18.md`
+- ADR-023: app substrate placement (no random `phenoShared`)
+- `packs/community-contributions/README.md` — absorption manifest
+
+---
+*Absorption commit: feat/community-packs-subtree-2026-06-18*
+*Recorded: 2026-06-18 by Forge (KooshaPari) for the kilo absorption closure*

--- a/docs/dinoforge-packs_AGENTS.md
+++ b/docs/dinoforge-packs_AGENTS.md
@@ -1,0 +1,74 @@
+# AGENTS.md — dinoforge-packs
+
+This file governs work inside the dinoforge-packs repository.
+
+## Identity
+
+dinoforge-packs is the DINOForge resource-pack repository for content packs
+consumed by the DINOForge framework.
+
+Follow the parent shelf instructions in
+`/Users/kooshapari/CodeProjects/Phenotype/repos/AGENTS.md` where they apply.
+Use this file for repo-specific guidance.
+
+## Required Operating Loop
+
+1. Check AgilePlus for existing specs before implementation
+2. Research code and tests before editing
+3. Keep changes scoped to a single feature or bug fix
+4. Validate with quality-gate checks (see below)
+5. Do not leave incomplete work or stub implementations
+
+## Canonical Surfaces
+
+- **Spec tracking:** AgilePlus at `/Users/kooshapari/CodeProjects/Phenotype/repos/AgilePlus`
+- **Work audit:** `docs/worklogs/README.md`
+- **Quality gates:** See `Governance Reference` below
+- **Build/test:** See project-specific targets (Makefile, Cargo.toml, package.json, etc.)
+
+## Quality Rules
+
+### Linting & Formatting
+
+All code MUST pass linting and formatting checks before commit:
+- Run linters and formatters locally (see CLAUDE.md for commands)
+- Fix errors; do not suppress or ignore warnings
+- Commit all formatting changes before feature changes
+
+### Testing & Specification Traceability
+
+- All tests MUST reference a Functional Requirement (FR) if FUNCTIONAL_REQUIREMENTS.md exists
+- Every FR MUST have at least 1 test
+- Run tests locally and verify pass before pushing
+
+### Documentation
+
+- Use Vale for Markdown validation where available
+- Keep docs organized per global structure: `docs/guides/`, `docs/reports/`, `docs/research/`, `docs/reference/`, `docs/checklists/`
+- Never create `.md` files at root level (except `README.md`, `CLAUDE.md`, `AGENTS.md`)
+
+## Governance Reference
+
+- **Global baseline:** `~/.claude/CLAUDE.md` (Dependency preferences, Prose quality, Context management, Failure behavior)
+- **Phenotype-org scripting:** `repos/docs/governance/scripting_policy.md` (Rust default; no new shell)
+- **CI/GitHub Actions:** See parent CLAUDE.md (billing constraint; skip macOS/Windows runners)
+- **Git discipline:** Phenotype Git and Delivery Workflow Protocol (parent CLAUDE.md)
+- **Child agents & delegation:** See parent CLAUDE.md (prefer subagents for multi-file work)
+
+## Worktree Pattern
+
+- **Feature work:** Use repo worktrees at `repos/[PROJECT]-wtrees/<topic>/`
+- **Canonical repo:** Always on `main` except during merge operations
+- **No feature branches in canonical:** All work isolated in worktrees until integration
+
+## Integration & Handoff
+
+When feature work is complete:
+1. Ensure all tests pass and quality gates are clean
+2. Create a pull request or squash-commit to `main`
+3. Update AgilePlus work package status
+4. Archive worktree or keep for reference
+
+---
+
+**Parent contract:** See `AGENTS.md` at `/Users/kooshapari/CodeProjects/Phenotype/repos/AGENTS.md` for cross-project agent coordination and parent shelf governance.

--- a/docs/dinoforge-packs_CHANGELOG.md
+++ b/docs/dinoforge-packs_CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security

--- a/docs/dinoforge-packs_CLAUDE.md
+++ b/docs/dinoforge-packs_CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md — dinoforge-packs
+
+Extends parent governance. See the following for canonical definitions:
+- **Global baseline:** `~/.claude/CLAUDE.md`
+- **Phenotype root:** `/Users/kooshapari/CodeProjects/Phenotype/repos/CLAUDE.md`
+- **AgilePlus mandate:** `/Users/kooshapari/CodeProjects/Phenotype/repos/AgilePlus`
+- **Governance reference:** `AGENTS.md` (local, this repository)
+
+## Project Overview
+
+- **Name:** dinoforge-packs
+- **Description:** [Short description from README]
+- **Location:** [Relative path in repos]
+- **Language Stack:** [Primary languages]
+- **Status:** [Active/Archived/Experimental]
+
+## AgilePlus Mandate
+
+All work MUST be tracked in AgilePlus:
+- CLI: `cd /Users/kooshapari/CodeProjects/Phenotype/repos/AgilePlus && agileplus <command>`
+- Check for existing specs before implementing
+- Create spec for new work: `agileplus specify --title "<feature>" --description "<desc>"`
+- No code without corresponding AgilePlus spec
+
+## Quality Checks
+
+From this repository root:
+```bash
+# Linting and formatting (adjust for project language)
+cargo clippy --workspace -- -D warnings
+cargo fmt --check
+
+# Testing
+cargo test --workspace
+
+# Documentation validation
+vale docs/
+```
+
+## Worktree & Git Discipline
+
+- Feature work uses repo-specific worktrees: `repos/[PROJECT]-wtrees/<topic>/`
+- Canonical repo stays on `main` except during explicit merge operations
+- All feature branches are temporary; integrate via pull request or squash commit
+- See parent governance for non-destructive change protocol
+
+## Cross-Project Reuse
+
+During development, proactively identify code that is sharable across Phenotype repositories. Prefer extraction into existing shared modules; propose new shared packages when appropriate.
+
+## Related Documents
+
+- `AGENTS.md` — Local agent contract and operating loop
+- `FUNCTIONAL_REQUIREMENTS.md` — Functional requirements and test traceability (if present)
+- `docs/worklogs/README.md` — Work audit and decision log
+- Parent `README.md` — Project-specific documentation
+
+---
+
+For CI, scripting language hierarchy, and other policies, see the canonical sources listed above.

--- a/docs/dinoforge-packs_FUNCTIONAL_REQUIREMENTS.md
+++ b/docs/dinoforge-packs_FUNCTIONAL_REQUIREMENTS.md
@@ -1,0 +1,55 @@
+# Functional Requirements
+
+All tests MUST reference an FR in this document. All FRs MUST have at least one test.
+
+## Requirements
+
+
+### FR-001: Dino skill pack loading and registration
+
+**Description:** 
+**Test Status:** Not yet written
+**Status:** Stub
+
+
+### FR-002: Package discovery and installation
+
+**Description:** 
+**Test Status:** Not yet written
+**Status:** Stub
+
+
+### FR-003: Skill composition and chaining
+
+**Description:** 
+**Test Status:** Not yet written
+**Status:** Stub
+
+
+### FR-004: Example balance and execution workflows
+
+**Description:** 
+**Test Status:** Not yet written
+**Status:** Stub
+
+
+### FR-005: StarWars domain-specific extensions
+
+**Description:** 
+**Test Status:** Not yet written
+**Status:** Stub
+
+
+### FR-006: Pack versioning and compatibility
+
+**Description:** 
+**Test Status:** Not yet written
+**Status:** Stub
+
+
+### FR-007: Skill documentation generation
+
+**Description:** 
+**Test Status:** Not yet written
+**Status:** Stub
+

--- a/packs/community-contributions/README.md
+++ b/packs/community-contributions/README.md
@@ -1,0 +1,39 @@
+# Community Contributions
+
+This directory holds pack contributions from external repositories that have
+been absorbed into the DINOForge fleet. Each subdirectory preserves a snapshot
+of the contributing repo at absorption time, including its docs, tests, and
+governance files.
+
+## Current absorbed repos
+
+| Directory | Source repo | Absorbed | Notes |
+|-----------|-------------|----------|-------|
+| `dinoforge-packs-mirror/` | `KooshaPari/dinoforge-packs` | 2026-06-18 | Reference content packs (example-balance) + stale warfare-starwars variant requiring ID migration |
+
+## Important: ID divergence warning
+
+The `dinoforge-packs-mirror/warfare-starwars/` manifest uses **legacy
+non-namespaced unit IDs** (e.g. `clone-trooper`, `b1-battle-droid`,
+`droideka`) that DO NOT EXIST in the canonical
+[`packs/warfare-starwars/`](../warfare-starwars/) pack.
+
+The canonical pack uses **namespaced unit IDs** (e.g. `rep_clone_trooper`,
+`cis_b1_droid`, `cis_droideka`) which match the unit definitions in
+`packs/warfare-starwars/units/`.
+
+**DO NOT load the mirrored manifest directly.** It is preserved as historical
+reference and as a migration source — the unit IDs must be remapped to the
+canonical namespaced form before this content can be used in DINO.
+
+See [`docs/dinoforge-packs-absorption.md`](../../docs/dinoforge-packs-absorption.md)
+for the full absorption matrix.
+
+## How to contribute
+
+1. Open a PR adding your pack under `packs/community-contributions/<your-repo-name>/`
+2. Manifest must declare `framework_version: ">=0.5.0 <1.0.0"` (with upper bound)
+3. Unit/building/faction IDs must use the `faction_kind` namespace prefix
+   (`rep_*`, `cis_*`, `cis_sep_*`, etc.) to avoid collision with vanilla content
+4. Include `manifest.yaml`, `pack.yaml`, and at least one faction + one unit
+5. PR must pass `go test ./tests/packs/...` smoke tests

--- a/packs/community-contributions/dinoforge-packs-mirror/docs/journeys/manifests/README.md
+++ b/packs/community-contributions/dinoforge-packs-mirror/docs/journeys/manifests/README.md
@@ -1,0 +1,1 @@
+# Journey Manifests

--- a/packs/community-contributions/dinoforge-packs-mirror/docs/operations/iconography/SPEC.md
+++ b/packs/community-contributions/dinoforge-packs-mirror/docs/operations/iconography/SPEC.md
@@ -1,0 +1,6 @@
+# Iconography Standard
+
+Implements the [phenotype-infra iconography standard](https://github.com/kooshapari/phenotype-infra/blob/main/docs/governance/iconography-standard.md).
+
+Three styles: Fluent (stroke), Material (filled+outlined), Liquid Glass (blur).
+All icons: 24×24 SVG, `currentColor`, `role="img"`, `aria-label`.

--- a/packs/community-contributions/dinoforge-packs-mirror/docs/operations/journey-traceability.md
+++ b/packs/community-contributions/dinoforge-packs-mirror/docs/operations/journey-traceability.md
@@ -1,0 +1,14 @@
+# Journey Traceability
+
+Implements the [phenotype-infra journey-traceability standard](https://github.com/kooshapari/phenotype-infra/blob/main/docs/governance/journey-traceability-standard.md).
+
+## User-Facing Flows
+
+Document key flows with journey manifests in `docs/journeys/manifests/`.
+
+## Status
+
+- [ ] Identify key user-facing flows
+- [ ] Record VHS tapes for each flow
+- [ ] Author manifests in `docs/journeys/manifests/`
+- [ ] Run `phenotype-journey verify` in CI

--- a/packs/community-contributions/dinoforge-packs-mirror/docs/sessions/20260428-taskfile-dinoforge-packs/00_SESSION_OVERVIEW.md
+++ b/packs/community-contributions/dinoforge-packs-mirror/docs/sessions/20260428-taskfile-dinoforge-packs/00_SESSION_OVERVIEW.md
@@ -1,0 +1,6 @@
+# Session Overview
+
+- Goal: add a repository `Taskfile.yml` with common `build`, `test`, `lint`, and `clean` tasks.
+- Scope: detect the repository language/tooling from repo contents and route tasks accordingly.
+- Validation: run the new Taskfile tasks in the cloned checkout before publishing.
+- Outcome target: open a PR, merge it with squash, and report the PR URL.

--- a/packs/community-contributions/dinoforge-packs-mirror/docs/sessions/20260428-taskfile-dinoforge-packs/01_RESEARCH.md
+++ b/packs/community-contributions/dinoforge-packs-mirror/docs/sessions/20260428-taskfile-dinoforge-packs/01_RESEARCH.md
@@ -1,0 +1,7 @@
+# Research
+
+- Repository contents are YAML-first content packs with a small Go smoke test in `tests/smoke_test.go`.
+- There is no `go.mod`, so Go commands must run with `GO111MODULE=off`.
+- `go test ./...` fails without module mode disabled.
+- `GO111MODULE=off go test ./...` passes.
+- `yamllint` is available locally, and the repo passes with a relaxed config that disables document-start and truthy checks and raises the line-length limit to 240.

--- a/packs/community-contributions/dinoforge-packs-mirror/docs/worklogs/README.md
+++ b/packs/community-contributions/dinoforge-packs-mirror/docs/worklogs/README.md
@@ -1,0 +1,55 @@
+# Work Audit — dinoforge-packs
+
+**Index:** Use the local worklog files under `docs/worklogs/` and the project `README.md` as the canonical entry point.
+
+## Purpose
+
+This log records research completions, architectural decisions, issues discovered (duplication, performance, governance), work completions, and planning artifacts (fork candidates, migration plans) for dinoforge-packs.
+
+## Worklog Categories
+
+All entries MUST be organized into one of these categories:
+
+| Category | File | Purpose |
+|----------|------|---------|
+| ARCHITECTURE | worklogs/ARCHITECTURE.md | ADRs, library extraction, major refactors |
+| DUPLICATION | worklogs/DUPLICATION.md | Cross-project code duplication |
+| DEPENDENCIES | worklogs/DEPENDENCIES.md | External deps, forks, modernization |
+| INTEGRATION | worklogs/INTEGRATION.md | External integrations, bridge contracts |
+| PERFORMANCE | worklogs/PERFORMANCE.md | Optimization, benchmarking, profiling |
+| RESEARCH | worklogs/RESEARCH.md | Starred repo analysis, technology research |
+| GOVERNANCE | worklogs/GOVERNANCE.md | Policy, evidence, quality gates, process |
+
+## When to Write
+
+Write an entry for:
+- Research completions (starred repos, tech eval, design exploration)
+- Significant decisions made (why we chose X over Y)
+- Issues found (duplication >50 LOC, performance bottlenecks, governance gaps)
+- Work completions (feature shipped, large refactor finished)
+- Planning (fork candidates, migration roadmaps, deprecation notices)
+
+## Format
+
+Each entry should include:
+- **Date** (YYYY-MM-DD)
+- **Category** (from table above)
+- **Title** (concise, searchable)
+- **Context** (what prompted this work)
+- **Finding/Decision** (what was discovered or decided)
+- **Impact** (how it affects this project or others)
+- **Project Tags** (e.g., `dinoforge-packs`, `[cross-repo]`)
+
+## Example
+
+```markdown
+### 2026-04-24 | DUPLICATION | Config loader duplication in 5 projects
+
+**Context:** Cross-project audit identified identical config loading patterns.
+**Finding:** 50+ LOC duplicated in BytePort, Civis, Dino, Eidolon, FocalPoint.
+**Decision:** Extract into phenotype-config-core shared crate.
+**Impact:** -250 LOC across 5 repos; single source of truth for config.
+**Tags:** `[cross-repo]` `[DUPLICATION]`
+```
+
+---

--- a/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/buildings/cis_buildings.yaml
+++ b/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/buildings/cis_buildings.yaml
@@ -1,0 +1,150 @@
+# CIS Buildings - Cheap, fast mass production
+
+- id: cis_tactical_center
+  display_name: Tactical Droid Center
+  description: Separatist command center housing the tactical droid coordinator.
+  building_type: command
+  health: 1400
+  cost:
+    food: 0
+    wood: 40
+    stone: 60
+    iron: 50
+    gold: 30
+    population: 0
+  production: {}
+
+- id: cis_droid_factory
+  display_name: Droid Factory
+  description: Automated assembly line mass-producing B1 battle droids at extreme rates.
+  building_type: barracks
+  health: 1000
+  cost:
+    food: 0
+    wood: 30
+    stone: 40
+    iron: 40
+    gold: 15
+    population: 0
+  production:
+    cis_b1_battle_droid: 6
+    cis_b1_squad: 3
+
+- id: cis_assembly_line
+  display_name: Advanced Assembly Line
+  description: Heavy manufacturing facility producing B2 droids and commando droids.
+  building_type: barracks
+  health: 800
+  cost:
+    food: 0
+    wood: 20
+    stone: 50
+    iron: 60
+    gold: 25
+    population: 0
+  production:
+    cis_b2_super_battle_droid: 2
+    cis_bx_commando_droid: 1
+
+- id: cis_heavy_foundry
+  display_name: Heavy Foundry
+  description: Vehicle and heavy weapons production facility for AATs and droidekas.
+  building_type: barracks
+  health: 900
+  cost:
+    food: 0
+    wood: 20
+    stone: 60
+    iron: 80
+    gold: 30
+    population: 0
+  production:
+    cis_aat_crew: 1
+    cis_droideka: 1
+
+- id: cis_sentry_turret
+  display_name: Sentry Turret
+  description: Automated blaster turret for perimeter defense.
+  building_type: defense
+  health: 500
+  cost:
+    food: 0
+    wood: 15
+    stone: 25
+    iron: 25
+    gold: 5
+    population: 0
+  production: {}
+
+- id: cis_ray_shield
+  display_name: Ray Shield Generator
+  description: Droid-operated ray shield projector blocking incoming fire.
+  building_type: defense
+  health: 1200
+  cost:
+    food: 0
+    wood: 10
+    stone: 60
+    iron: 80
+    gold: 40
+    population: 0
+  production: {}
+
+- id: cis_mining_facility
+  display_name: Mining Facility
+  description: Automated mineral extraction operation providing raw materials.
+  building_type: economy
+  health: 600
+  cost:
+    food: 0
+    wood: 20
+    stone: 30
+    iron: 20
+    gold: 8
+    population: 0
+  production:
+    iron: 4
+    stone: 2
+
+- id: cis_processing_plant
+  display_name: Processing Plant
+  description: Refinery converting raw materials into trade goods.
+  building_type: economy
+  health: 500
+  cost:
+    food: 0
+    wood: 15
+    stone: 25
+    iron: 30
+    gold: 10
+    population: 0
+  production:
+    gold: 3
+
+- id: cis_tech_union_lab
+  display_name: Techno Union Lab
+  description: Techno Union research facility developing advanced droid designs.
+  building_type: research
+  health: 700
+  cost:
+    food: 0
+    wood: 20
+    stone: 40
+    iron: 50
+    gold: 35
+    population: 0
+  production: {}
+
+- id: cis_durasteel_barrier
+  display_name: Durasteel Barrier
+  description: Prefabricated wall segment for rapid base fortification.
+  building_type: defense
+  health: 900
+  cost:
+    food: 0
+    wood: 0
+    stone: 40
+    iron: 25
+    gold: 0
+    population: 0
+  production: {}

--- a/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/buildings/republic_buildings.yaml
+++ b/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/buildings/republic_buildings.yaml
@@ -1,0 +1,150 @@
+# Galactic Republic Buildings
+
+- id: rep_command_center
+  display_name: Republic Command Center
+  description: Central operations hub coordinating all Republic forces in the sector.
+  building_type: command
+  health: 2200
+  cost:
+    food: 0
+    wood: 80
+    stone: 150
+    iron: 100
+    gold: 60
+    population: 0
+  production: {}
+
+- id: rep_clone_facility
+  display_name: Clone Training Facility
+  description: Clone trooper deployment center producing militia and standard clone troopers.
+  building_type: barracks
+  health: 1300
+  cost:
+    food: 0
+    wood: 60
+    stone: 80
+    iron: 50
+    gold: 25
+    population: 0
+  production:
+    rep_clone_militia: 2
+    rep_clone_trooper: 1
+
+- id: rep_weapons_factory
+  display_name: Weapons Factory
+  description: Advanced weapons manufacturing facility producing heavy troopers and ARC troopers.
+  building_type: barracks
+  health: 1100
+  cost:
+    food: 0
+    wood: 50
+    stone: 80
+    iron: 80
+    gold: 40
+    population: 0
+  production:
+    rep_clone_heavy: 1
+    rep_arc_trooper: 1
+
+- id: rep_vehicle_bay
+  display_name: Vehicle Bay
+  description: Republic motor pool for AT-TE walkers and BARC speeders.
+  building_type: barracks
+  health: 1000
+  cost:
+    food: 0
+    wood: 40
+    stone: 60
+    iron: 120
+    gold: 50
+    population: 0
+  production:
+    rep_atte_crew: 1
+    rep_barc_speeder: 1
+
+- id: rep_guard_tower
+  display_name: Guard Tower
+  description: Elevated defensive position with mounted blaster turret.
+  building_type: defense
+  health: 700
+  cost:
+    food: 0
+    wood: 40
+    stone: 50
+    iron: 35
+    gold: 10
+    population: 0
+  production: {}
+
+- id: rep_shield_generator
+  display_name: Shield Generator
+  description: Deflector shield generator protecting a wide area from ranged fire.
+  building_type: defense
+  health: 1500
+  cost:
+    food: 0
+    wood: 20
+    stone: 100
+    iron: 120
+    gold: 60
+    population: 0
+  production: {}
+
+- id: rep_supply_station
+  display_name: Supply Station
+  description: Republic logistics hub providing steady resource income.
+  building_type: economy
+  health: 800
+  cost:
+    food: 0
+    wood: 50
+    stone: 40
+    iron: 25
+    gold: 10
+    population: 0
+  production:
+    food: 5
+    iron: 2
+
+- id: rep_tibanna_refinery
+  display_name: Tibanna Gas Refinery
+  description: Processes tibanna gas for blaster ammunition and trade.
+  building_type: economy
+  health: 700
+  cost:
+    food: 0
+    wood: 30
+    stone: 50
+    iron: 40
+    gold: 20
+    population: 0
+  production:
+    gold: 4
+
+- id: rep_research_lab
+  display_name: Research Laboratory
+  description: Republic R&D facility unlocking advanced clone and vehicle upgrades.
+  building_type: research
+  health: 900
+  cost:
+    food: 0
+    wood: 40
+    stone: 70
+    iron: 60
+    gold: 50
+    population: 0
+  production: {}
+
+- id: rep_blast_wall
+  display_name: Blast Wall
+  description: Reinforced durasteel wall segment for perimeter defense.
+  building_type: defense
+  health: 1600
+  cost:
+    food: 0
+    wood: 5
+    stone: 70
+    iron: 30
+    gold: 0
+    population: 0
+  production: {}

--- a/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/doctrines/cis_doctrines.yaml
+++ b/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/doctrines/cis_doctrines.yaml
@@ -1,0 +1,31 @@
+# CIS Doctrines
+
+- id: mechanized_attrition
+  display_name: Mechanized Attrition
+  description: Drown the enemy in expendable droids. Maximize production speed and unit count at the expense of individual quality.
+  faction_archetype: industrial_swarm
+  modifiers:
+    spawn_rate: 1.5
+    cost: 0.7
+    hp: 0.85
+    damage: 0.9
+
+- id: rolling_thunder
+  display_name: Rolling Thunder
+  description: Mass armored assault combining AATs and B2 droids for a relentless mechanical advance.
+  faction_archetype: industrial_swarm
+  modifiers:
+    armor: 1.2
+    damage: 1.15
+    speed: 0.9
+    cost: 1.15
+
+- id: swarm_protocol
+  display_name: Swarm Protocol
+  description: Maximized droid throughput with aggressive forward movement and overwhelming fire volume.
+  faction_archetype: industrial_swarm
+  modifiers:
+    fire_rate: 1.3
+    speed: 1.15
+    accuracy: 0.8
+    spawn_rate: 1.3

--- a/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/doctrines/republic_doctrines.yaml
+++ b/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/doctrines/republic_doctrines.yaml
@@ -1,0 +1,31 @@
+# Galactic Republic Doctrines
+
+- id: elite_discipline
+  display_name: Elite Discipline
+  description: Clone troopers fight with superior training and discipline, maximizing accuracy and morale retention.
+  faction_archetype: order
+  modifiers:
+    accuracy: 1.15
+    morale: 1.2
+    fire_rate: 1.05
+    damage: 1.05
+
+- id: jedi_leadership
+  display_name: Jedi Leadership
+  description: Jedi generals inspire clone forces, boosting morale and movement speed in offensive operations.
+  faction_archetype: order
+  modifiers:
+    morale: 1.3
+    speed: 1.15
+    damage: 1.1
+    cost: 1.1
+
+- id: defensive_formation
+  display_name: Defensive Formation
+  description: Disciplined defensive posture maximizing fortification effectiveness and ranged defense.
+  faction_archetype: order
+  modifiers:
+    armor: 1.2
+    range: 1.1
+    hp: 1.1
+    speed: 0.9

--- a/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/factions/cis.yaml
+++ b/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/factions/cis.yaml
@@ -1,0 +1,54 @@
+# Confederacy of Independent Systems - Industrial Swarm Archetype
+# Mass-produced droid army, cheap and expendable
+
+faction:
+  id: cis
+  display_name: Confederacy of Independent Systems
+  description: The Separatist droid army, mass-produced in vast factories. Individually weak but produced in overwhelming numbers with mechanical discipline.
+  theme: starwars
+  archetype: industrial_swarm
+  doctrine: mechanized_attrition
+
+economy:
+  gather_bonus: 0.9
+  upkeep_modifier: 0.6
+  research_speed: 0.9
+  build_speed: 1.4
+
+army:
+  morale_style: mechanical
+  unit_cap_modifier: 1.6
+  elite_cost_modifier: 1.3
+  spawn_rate_modifier: 1.5
+
+roster:
+  cheap_infantry: cis_b1_battle_droid
+  line_infantry: cis_b1_squad
+  elite_infantry: cis_bx_commando_droid
+  anti_armor: cis_b2_super_battle_droid
+  support_weapon: cis_aat_crew
+  recon: cis_probe_droid
+  light_vehicle: cis_stap_pilot
+  heavy_vehicle: cis_droideka
+  artillery: cis_aat_crew
+  hero_commander: cis_general_grievous
+  spike_unit: cis_magnaguard
+
+buildings:
+  barracks: cis_droid_factory
+  workshop: cis_assembly_line
+  artillery_foundry: cis_heavy_foundry
+  tower_mg: cis_sentry_turret
+  heavy_defense: cis_ray_shield
+  command_center: cis_tactical_center
+  economy_primary: cis_mining_facility
+  economy_secondary: cis_processing_plant
+  research_facility: cis_tech_union_lab
+  wall_segment: cis_durasteel_barrier
+
+visuals:
+  primary_color: "#4A5568"
+  accent_color: "#3182CE"
+
+audio:
+  weapon_pack: starwars_weapons

--- a/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/factions/republic.yaml
+++ b/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/factions/republic.yaml
@@ -1,0 +1,54 @@
+# Galactic Republic Faction - Order Archetype
+# Disciplined clone army with Jedi leadership
+
+faction:
+  id: republic
+  display_name: Galactic Republic
+  description: The Grand Army of the Republic, composed of disciplined clone troopers led by Jedi commanders. Balanced forces with strong morale and combined arms tactics.
+  theme: starwars
+  archetype: order
+  doctrine: elite_discipline
+
+economy:
+  gather_bonus: 1.0
+  upkeep_modifier: 1.1
+  research_speed: 1.1
+  build_speed: 1.0
+
+army:
+  morale_style: disciplined
+  unit_cap_modifier: 1.0
+  elite_cost_modifier: 0.9
+  spawn_rate_modifier: 1.0
+
+roster:
+  cheap_infantry: rep_clone_militia
+  line_infantry: rep_clone_trooper
+  elite_infantry: rep_arc_trooper
+  anti_armor: rep_clone_heavy
+  support_weapon: rep_atte_crew
+  recon: rep_arf_trooper
+  light_vehicle: rep_barc_speeder
+  heavy_vehicle: rep_clone_wall_guard
+  artillery: rep_atte_crew
+  hero_commander: rep_jedi_knight
+  spike_unit: rep_clone_commando
+
+buildings:
+  barracks: rep_clone_facility
+  workshop: rep_weapons_factory
+  artillery_foundry: rep_vehicle_bay
+  tower_mg: rep_guard_tower
+  heavy_defense: rep_shield_generator
+  command_center: rep_command_center
+  economy_primary: rep_supply_station
+  economy_secondary: rep_tibanna_refinery
+  research_facility: rep_research_lab
+  wall_segment: rep_blast_wall
+
+visuals:
+  primary_color: "#FFFFFF"
+  accent_color: "#CC0000"
+
+audio:
+  weapon_pack: starwars_weapons

--- a/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/manifest.yaml
+++ b/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/manifest.yaml
@@ -1,0 +1,69 @@
+id: warfare-starwars
+name: "Star Wars: The Clone Wars"
+version: 0.1.0
+type: total_conversion
+author: DINOForge Agents
+theme: star-wars
+description: "Replaces all factions with Star Wars Clone Wars equivalents. Republic vs CIS vs Separatist forces."
+framework_version: ">=0.5.0"
+singleton: true
+
+replaces_vanilla:
+  player: galactic-republic
+  enemy_classic: confederacy-of-independent-systems
+  enemy_guerrilla: separatist-extremists
+
+factions:
+  - id: galactic-republic
+    replaces: player
+    name: "Galactic Republic"
+    theme: star-wars-republic
+    archetype: order
+    units:
+      - clone-trooper
+      - arc-trooper
+      - at-te
+      - clone-gunship
+    buildings:
+      - republic-command-post
+      - republic-barracks
+      - republic-turret
+
+  - id: confederacy-of-independent-systems
+    replaces: enemy_classic
+    name: "Confederacy of Independent Systems"
+    theme: star-wars-cis
+    archetype: industrial_swarm
+    units:
+      - b1-battle-droid
+      - b2-super-battle-droid
+      - droideka
+      - hailfire-droid
+    buildings:
+      - cis-factory
+      - cis-command-center
+      - droid-dispenser
+
+  - id: separatist-extremists
+    replaces: enemy_guerrilla
+    name: "Separatist Extremists"
+    theme: star-wars-cis-guerrilla
+    archetype: asymmetric
+    units:
+      - commando-droid
+      - magna-guard
+      - infiltration-unit
+    buildings:
+      - hidden-base
+      - separatist-cache
+
+asset_replacements:
+  textures:
+    "textures/ui/faction_icon_player": "assets/textures/republic_icon.png"
+    "textures/ui/faction_icon_enemy": "assets/textures/cis_icon.png"
+  audio:
+    "audio/music/battle_theme": "assets/audio/clone_wars_theme.ogg"
+
+conflicts_with:
+  - warfare-modern
+  - warfare-guerrilla

--- a/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/pack.yaml
+++ b/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/pack.yaml
@@ -1,0 +1,41 @@
+# Star Wars Warfare Pack
+# Republic vs CIS - Clone Wars themed total conversion
+
+id: warfare-starwars
+name: Star Wars - Clone Wars
+version: 0.1.0
+framework_version: ">=0.1.0"
+author: DINOForge
+description: |
+  A total conversion transporting DINO into the Star Wars universe during the Clone Wars. Command the clone trooper legions of the Galactic Republic against the mechanized forces of the Separatist Confederacy.
+
+  Factions included:
+  - Galactic Republic: disciplined elite clone army with Jedi commanders, strong morale, and specialized forces
+  - Confederacy (CIS): mechanized swarm doctrine with rolling thunder tactics and droid legions
+
+  Content features:
+  - 26 units per side: clone troopers, arc troopers, heavy troops, vehicle crews, ARF troopers, speeder pilots, jedi knights, commandos, battle droids, super battle droids
+  - 20 buildings: clone facilities, weapons factories, vehicle bays, guard towers, shield generators, command centers, supply stations, tibanna refineries, research labs, blast walls
+  - 6 doctrines: elite discipline, jedi leadership, defensive formation, mechanized attrition, rolling thunder, swarm protocol
+  - 1 weapon set: blasters and energy weapons
+  - Clone Wars wave templates for themed campaigns
+
+  Experience the conflict between biological discipline and mechanical coordination in a galaxy far, far away.
+type: total_conversion
+
+depends_on: []
+conflicts_with: []
+
+loads:
+  factions:
+    - factions
+  units:
+    - units
+  weapons:
+    - weapons
+  buildings:
+    - buildings
+  doctrines:
+    - doctrines
+  wave_templates:
+    - waves

--- a/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/units/cis_units.yaml
+++ b/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/units/cis_units.yaml
@@ -1,0 +1,366 @@
+# Confederacy of Independent Systems Units - Industrial Swarm Archetype
+# Cheap droids, low individual stats, mass production
+
+# 1. Militia - B1 Battle Droid
+- id: cis_b1_battle_droid
+  display_name: B1 Battle Droid
+  description: "Roger roger. Basic battle droid, cheap and expendable. Weak individually but dangerous in masses."
+  unit_class: MilitiaLight
+  faction_id: cis
+  tier: 1
+  weapon: e5_blaster
+  vanilla_mapping: militia
+  defense_tags: [Unarmored, Mechanical]
+  behavior_tags: [Swarm]
+  stats:
+    hp: 40.0
+    damage: 9.0
+    armor: 1.0
+    range: 16.0
+    speed: 4.5
+    accuracy: 0.35
+    fire_rate: 3.0
+    morale: 200.0
+    cost:
+      food: 0
+      wood: 0
+      stone: 0
+      iron: 8
+      gold: 3
+      population: 1
+
+# 2. Line Infantry - B1 Squad
+- id: cis_b1_squad
+  display_name: B1 Squad
+  description: Coordinated B1 squad with marginally better tactics via improved droid brains.
+  unit_class: CoreLineInfantry
+  faction_id: cis
+  tier: 1
+  weapon: e5_blaster
+  vanilla_mapping: line_infantry
+  defense_tags: [Unarmored, Mechanical]
+  behavior_tags: [Swarm, AdvanceFire]
+  stats:
+    hp: 50.0
+    damage: 9.0
+    armor: 2.0
+    range: 16.0
+    speed: 4.5
+    accuracy: 0.45
+    fire_rate: 3.0
+    morale: 200.0
+    cost:
+      food: 0
+      wood: 0
+      stone: 0
+      iron: 12
+      gold: 5
+      population: 1
+
+# 3. Heavy Infantry - B2 Super Battle Droid
+- id: cis_b2_super_battle_droid
+  display_name: B2 Super Battle Droid
+  description: Heavily armored battle droid with integrated wrist blasters. Tougher but more expensive.
+  unit_class: HeavyInfantry
+  faction_id: cis
+  tier: 2
+  weapon: wrist_blaster
+  vanilla_mapping: heavy_infantry
+  defense_tags: [HeavyArmor, Mechanical]
+  behavior_tags: [AdvanceFire, Swarm]
+  stats:
+    hp: 160.0
+    damage: 14.0
+    armor: 10.0
+    range: 18.0
+    speed: 3.5
+    accuracy: 0.55
+    fire_rate: 4.0
+    morale: 200.0
+    cost:
+      food: 0
+      wood: 0
+      stone: 0
+      iron: 30
+      gold: 15
+      population: 1
+
+# 4. Ranged Infantry - Sniper Droid
+- id: cis_sniper_droid
+  display_name: Sniper Droid
+  description: Modified B1 unit with enhanced optics and sniper-class blaster for long-range engagement.
+  unit_class: Skirmisher
+  faction_id: cis
+  tier: 2
+  weapon: e5s_sniper
+  vanilla_mapping: ranged_infantry
+  defense_tags: [Unarmored, Mechanical]
+  behavior_tags: [Kite]
+  stats:
+    hp: 35.0
+    damage: 30.0
+    armor: 1.0
+    range: 35.0
+    speed: 4.0
+    accuracy: 0.7
+    fire_rate: 0.6
+    morale: 200.0
+    cost:
+      food: 0
+      wood: 0
+      stone: 0
+      iron: 18
+      gold: 10
+      population: 1
+
+# 5. Cavalry - STAP Pilot
+- id: cis_stap_pilot
+  display_name: STAP Pilot
+  description: Single Trooper Aerial Platform, fast repulsorlift vehicle for flanking and harassment.
+  unit_class: FastVehicle
+  faction_id: cis
+  tier: 1
+  weapon: stap_blaster
+  vanilla_mapping: cavalry
+  defense_tags: [Unarmored, Mechanical]
+  behavior_tags: [Charge, Kite]
+  stats:
+    hp: 80.0
+    damage: 10.0
+    armor: 3.0
+    range: 18.0
+    speed: 11.0
+    accuracy: 0.4
+    fire_rate: 6.0
+    morale: 200.0
+    cost:
+      food: 0
+      wood: 0
+      stone: 0
+      iron: 20
+      gold: 8
+      population: 1
+
+# 6. Siege - AAT Crew
+- id: cis_aat_crew
+  display_name: AAT Crew
+  description: Armored Assault Tank providing heavy fire support and siege capability.
+  unit_class: MainBattleVehicle
+  faction_id: cis
+  tier: 2
+  weapon: aat_cannon
+  vanilla_mapping: siege
+  defense_tags: [HeavyArmor, Mechanical]
+  behavior_tags: [SiegePriority, AntiStructure]
+  stats:
+    hp: 350.0
+    damage: 55.0
+    armor: 18.0
+    range: 35.0
+    speed: 3.0
+    accuracy: 0.5
+    fire_rate: 0.25
+    morale: 200.0
+    cost:
+      food: 0
+      wood: 0
+      stone: 0
+      iron: 70
+      gold: 35
+      population: 3
+
+# 7. Support - Medical Droid
+- id: cis_medical_droid
+  display_name: Medical Droid
+  description: Repurposed medical unit providing repair functions to damaged battle droids.
+  unit_class: SupportEngineer
+  faction_id: cis
+  tier: 1
+  weapon: e5_blaster
+  vanilla_mapping: support
+  defense_tags: [Unarmored, Mechanical]
+  behavior_tags: [HoldLine]
+  stats:
+    hp: 50.0
+    damage: 5.0
+    armor: 1.0
+    range: 14.0
+    speed: 4.5
+    accuracy: 0.3
+    fire_rate: 2.0
+    morale: 200.0
+    cost:
+      food: 0
+      wood: 0
+      stone: 0
+      iron: 10
+      gold: 8
+      population: 1
+
+# 8. Scout - Probe Droid
+- id: cis_probe_droid
+  display_name: Probe Droid
+  description: DRK-1 probe droid used for reconnaissance with extended sensor range.
+  unit_class: Recon
+  faction_id: cis
+  tier: 1
+  weapon: e5_blaster
+  vanilla_mapping: scout
+  defense_tags: [Unarmored, Mechanical]
+  behavior_tags: [Kite]
+  stats:
+    hp: 30.0
+    damage: 6.0
+    armor: 0.0
+    range: 14.0
+    speed: 9.0
+    accuracy: 0.4
+    fire_rate: 2.0
+    morale: 200.0
+    cost:
+      food: 0
+      wood: 0
+      stone: 0
+      iron: 8
+      gold: 5
+      population: 1
+
+# 9. Elite - BX Commando Droid
+- id: cis_bx_commando_droid
+  display_name: BX Commando Droid
+  description: Advanced commando droid with superior agility, combat programming, and vibrosword capability.
+  unit_class: EliteLineInfantry
+  faction_id: cis
+  tier: 3
+  weapon: e5_blaster
+  vanilla_mapping: elite
+  defense_tags: [InfantryArmor, Mechanical]
+  behavior_tags: [Charge, AdvanceFire]
+  stats:
+    hp: 120.0
+    damage: 14.0
+    armor: 6.0
+    range: 18.0
+    speed: 7.0
+    accuracy: 0.75
+    fire_rate: 3.5
+    morale: 200.0
+    cost:
+      food: 0
+      wood: 0
+      stone: 0
+      iron: 35
+      gold: 25
+      population: 1
+
+# 10. Hero - General Grievous
+- id: cis_general_grievous
+  display_name: General Grievous
+  description: Supreme Commander of the Droid Army. A devastating melee combatant wielding four lightsabers.
+  unit_class: HeroCommander
+  faction_id: cis
+  tier: 3
+  weapon: grievous_lightsabers
+  vanilla_mapping: hero
+  defense_tags: [HeavyArmor, Mechanical, Heroic]
+  behavior_tags: [Charge, MoralePressure]
+  stats:
+    hp: 350.0
+    damage: 60.0
+    armor: 18.0
+    range: 2.5
+    speed: 7.0
+    accuracy: 0.9
+    fire_rate: 4.0
+    morale: 200.0
+    cost:
+      food: 0
+      wood: 0
+      stone: 0
+      iron: 50
+      gold: 120
+      population: 3
+
+# 11. Wall Defender - Droideka
+- id: cis_droideka
+  display_name: Droideka
+  description: Destroyer droid with personal deflector shield and twin rapid-fire blasters. Devastating in defense.
+  unit_class: StaticMG
+  faction_id: cis
+  tier: 3
+  weapon: droideka_blasters
+  vanilla_mapping: wall_defender
+  defense_tags: [Shielded, Mechanical]
+  behavior_tags: [HoldLine, AntiMass]
+  stats:
+    hp: 100.0
+    damage: 12.0
+    armor: 5.0
+    range: 20.0
+    speed: 2.0
+    accuracy: 0.55
+    fire_rate: 10.0
+    morale: 200.0
+    cost:
+      food: 0
+      wood: 0
+      stone: 0
+      iron: 45
+      gold: 30
+      population: 2
+
+# 12. Skirmisher - DSD1 Dwarf Spider Droid
+- id: cis_dwarf_spider_droid
+  display_name: DSD1 Dwarf Spider Droid
+  description: Small walking tank with a powerful central cannon for medium-range fire support.
+  unit_class: StaticAT
+  faction_id: cis
+  tier: 2
+  weapon: dwarf_spider_cannon
+  vanilla_mapping: skirmisher
+  defense_tags: [HeavyArmor, Mechanical]
+  behavior_tags: [AdvanceFire, AntiArmor]
+  stats:
+    hp: 180.0
+    damage: 35.0
+    armor: 12.0
+    range: 30.0
+    speed: 3.0
+    accuracy: 0.6
+    fire_rate: 0.5
+    morale: 200.0
+    cost:
+      food: 0
+      wood: 0
+      stone: 0
+      iron: 40
+      gold: 20
+      population: 2
+
+# 13. Special - MagnaGuard
+- id: cis_magnaguard
+  display_name: IG-100 MagnaGuard
+  description: Elite bodyguard droids wielding electrostaffs. Grievous's personal guard and anti-Jedi specialists.
+  unit_class: ShieldedElite
+  faction_id: cis
+  tier: 3
+  weapon: electrostaff
+  vanilla_mapping: special
+  defense_tags: [HeavyArmor, Mechanical]
+  behavior_tags: [Charge, AntiArmor]
+  stats:
+    hp: 200.0
+    damage: 30.0
+    armor: 14.0
+    range: 2.0
+    speed: 5.5
+    accuracy: 0.85
+    fire_rate: 2.0
+    morale: 200.0
+    cost:
+      food: 0
+      wood: 0
+      stone: 0
+      iron: 50
+      gold: 40
+      population: 2

--- a/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/units/clone-trooper.yaml
+++ b/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/units/clone-trooper.yaml
@@ -1,0 +1,23 @@
+id: clone-trooper
+display_name: "Clone Trooper"
+faction_id: galactic-republic
+unit_class: CoreLineInfantry
+tier: 1
+description: "Standard Republic infantry. Disciplined, accurate, and reliable."
+stats:
+  hp: 100
+  damage: 25
+  armor: 15
+  range: 8.0
+  speed: 3.5
+  accuracy: 0.8
+  fire_rate: 1.2
+  morale: 120
+  cost:
+    manpower: 40
+    supply: 5
+defense_tags:
+  - InfantryArmor
+behavior_tags:
+  - HoldLine
+  - AdvanceFire

--- a/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/units/republic_units.yaml
+++ b/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/units/republic_units.yaml
@@ -1,0 +1,366 @@
+# Galactic Republic Units - Order Archetype
+# Disciplined clones, balanced stats, moderate cost
+
+# 1. Militia - Clone Militia
+- id: rep_clone_militia
+  display_name: Clone Militia
+  description: Phase I clone troopers with basic training and standard-issue carbines.
+  unit_class: MilitiaLight
+  faction_id: republic
+  tier: 1
+  weapon: dc15s_carbine
+  vanilla_mapping: militia
+  defense_tags: [InfantryArmor, Biological]
+  behavior_tags: [HoldLine]
+  stats:
+    hp: 85.0
+    damage: 10.0
+    armor: 3.0
+    range: 16.0
+    speed: 5.0
+    accuracy: 0.65
+    fire_rate: 4.0
+    morale: 80.0
+    cost:
+      food: 30
+      wood: 0
+      stone: 0
+      iron: 10
+      gold: 8
+      population: 1
+
+# 2. Line Infantry - Clone Trooper
+- id: rep_clone_trooper
+  display_name: Clone Trooper
+  description: Standard Phase II clone trooper, the backbone of the Grand Army of the Republic.
+  unit_class: CoreLineInfantry
+  faction_id: republic
+  tier: 1
+  weapon: dc15a_blaster
+  vanilla_mapping: line_infantry
+  defense_tags: [InfantryArmor, Biological]
+  behavior_tags: [HoldLine, AdvanceFire]
+  stats:
+    hp: 125.0
+    damage: 14.0
+    armor: 6.0
+    range: 20.0
+    speed: 4.5
+    accuracy: 0.75
+    fire_rate: 2.5
+    morale: 95.0
+    cost:
+      food: 40
+      wood: 0
+      stone: 0
+      iron: 20
+      gold: 12
+      population: 1
+
+# 3. Heavy Infantry - Clone Heavy
+- id: rep_clone_heavy
+  display_name: Clone Heavy Trooper
+  description: Heavy weapons specialist wielding the Z-6 rotary blaster cannon for suppressive fire.
+  unit_class: HeavyInfantry
+  faction_id: republic
+  tier: 2
+  weapon: z6_rotary_cannon
+  vanilla_mapping: heavy_infantry
+  defense_tags: [HeavyArmor, Biological]
+  behavior_tags: [HoldLine, AntiMass]
+  stats:
+    hp: 155.0
+    damage: 10.0
+    armor: 8.0
+    range: 18.0
+    speed: 3.5
+    accuracy: 0.55
+    fire_rate: 8.0
+    morale: 90.0
+    cost:
+      food: 50
+      wood: 0
+      stone: 0
+      iron: 35
+      gold: 22
+      population: 2
+
+# 4. Ranged Infantry - Clone Sharpshooter
+- id: rep_clone_sharpshooter
+  display_name: Clone Sharpshooter
+  description: Precision marksman trained in long-range engagement and target elimination.
+  unit_class: Skirmisher
+  faction_id: republic
+  tier: 2
+  weapon: dc15x_sniper
+  vanilla_mapping: ranged_infantry
+  defense_tags: [InfantryArmor, Biological]
+  behavior_tags: [Kite, AdvanceFire]
+  stats:
+    hp: 90.0
+    damage: 40.0
+    armor: 3.0
+    range: 40.0
+    speed: 4.0
+    accuracy: 0.9
+    fire_rate: 0.5
+    morale: 85.0
+    cost:
+      food: 40
+      wood: 0
+      stone: 0
+      iron: 25
+      gold: 18
+      population: 1
+
+# 5. Cavalry - BARC Speeder
+- id: rep_barc_speeder
+  display_name: BARC Speeder
+  description: Fast reconnaissance and attack speeder bike used for flanking and pursuit.
+  unit_class: FastVehicle
+  faction_id: republic
+  tier: 2
+  weapon: dc15s_carbine
+  vanilla_mapping: cavalry
+  defense_tags: [HeavyArmor, Mechanical]
+  behavior_tags: [Charge, AdvanceFire]
+  stats:
+    hp: 180.0
+    damage: 12.0
+    armor: 10.0
+    range: 18.0
+    speed: 10.0
+    accuracy: 0.5
+    fire_rate: 4.0
+    morale: 85.0
+    cost:
+      food: 20
+      wood: 0
+      stone: 0
+      iron: 50
+      gold: 30
+      population: 2
+
+# 6. Siege - AT-TE Crew
+- id: rep_atte_crew
+  display_name: AT-TE Crew
+  description: All Terrain Tactical Enforcer crew providing heavy fire support and siege capability.
+  unit_class: MainBattleVehicle
+  faction_id: republic
+  tier: 3
+  weapon: atte_mass_driver
+  vanilla_mapping: siege
+  defense_tags: [HeavyArmor, Mechanical]
+  behavior_tags: [SiegePriority, AntiStructure]
+  stats:
+    hp: 400.0
+    damage: 65.0
+    armor: 20.0
+    range: 40.0
+    speed: 2.5
+    accuracy: 0.6
+    fire_rate: 0.2
+    morale: 100.0
+    cost:
+      food: 30
+      wood: 0
+      stone: 0
+      iron: 100
+      gold: 60
+      population: 4
+
+# 7. Support - Clone Medic
+- id: rep_clone_medic
+  display_name: Clone Medic
+  description: Battlefield medical specialist providing healing and triage to wounded clones.
+  unit_class: SupportEngineer
+  faction_id: republic
+  tier: 2
+  weapon: dc17_pistol
+  vanilla_mapping: support
+  defense_tags: [InfantryArmor, Biological]
+  behavior_tags: [HoldLine]
+  stats:
+    hp: 95.0
+    damage: 8.0
+    armor: 4.0
+    range: 12.0
+    speed: 5.0
+    accuracy: 0.6
+    fire_rate: 3.0
+    morale: 95.0
+    cost:
+      food: 40
+      wood: 0
+      stone: 0
+      iron: 15
+      gold: 20
+      population: 1
+
+# 8. Scout - ARF Trooper
+- id: rep_arf_trooper
+  display_name: ARF Trooper
+  description: Advanced Recon Force trooper trained for reconnaissance and forward observation.
+  unit_class: Recon
+  faction_id: republic
+  tier: 1
+  weapon: dc15s_carbine
+  vanilla_mapping: scout
+  defense_tags: [InfantryArmor, Biological]
+  behavior_tags: [Kite]
+  stats:
+    hp: 75.0
+    damage: 10.0
+    armor: 3.0
+    range: 16.0
+    speed: 7.0
+    accuracy: 0.7
+    fire_rate: 4.0
+    morale: 80.0
+    cost:
+      food: 30
+      wood: 0
+      stone: 0
+      iron: 12
+      gold: 10
+      population: 1
+
+# 9. Elite - ARC Trooper
+- id: rep_arc_trooper
+  display_name: ARC Trooper
+  description: Advanced Recon Commando, elite clone troopers trained for independent special operations.
+  unit_class: EliteLineInfantry
+  faction_id: republic
+  tier: 3
+  weapon: dc15a_blaster
+  vanilla_mapping: elite
+  defense_tags: [HeavyArmor, Biological]
+  behavior_tags: [AdvanceFire, Charge]
+  stats:
+    hp: 190.0
+    damage: 18.0
+    armor: 10.0
+    range: 22.0
+    speed: 5.5
+    accuracy: 0.9
+    fire_rate: 3.0
+    morale: 120.0
+    cost:
+      food: 60
+      wood: 0
+      stone: 0
+      iron: 45
+      gold: 45
+      population: 2
+
+# 10. Hero - Jedi Knight
+- id: rep_jedi_knight
+  display_name: Jedi Knight
+  description: Jedi commander wielding a lightsaber and the Force. Inspires troops and devastates in melee.
+  unit_class: HeroCommander
+  faction_id: republic
+  tier: 3
+  weapon: lightsaber
+  vanilla_mapping: hero
+  defense_tags: [Shielded, Biological, Heroic]
+  behavior_tags: [Charge, MoralePressure]
+  stats:
+    hp: 300.0
+    damage: 50.0
+    armor: 15.0
+    range: 2.0
+    speed: 6.5
+    accuracy: 0.95
+    fire_rate: 2.5
+    morale: 180.0
+    cost:
+      food: 80
+      wood: 0
+      stone: 0
+      iron: 30
+      gold: 100
+      population: 3
+
+# 11. Wall Defender - Clone Wall Guard
+- id: rep_clone_wall_guard
+  display_name: Clone Wall Guard
+  description: Garrison clone trooper specialized in fortification defense with heavy repeating blasters.
+  unit_class: StaticMG
+  faction_id: republic
+  tier: 2
+  weapon: z6_rotary_cannon
+  vanilla_mapping: wall_defender
+  defense_tags: [Fortified, Biological]
+  behavior_tags: [HoldLine, AntiMass]
+  stats:
+    hp: 135.0
+    damage: 10.0
+    armor: 12.0
+    range: 20.0
+    speed: 2.5
+    accuracy: 0.6
+    fire_rate: 8.0
+    morale: 100.0
+    cost:
+      food: 40
+      wood: 0
+      stone: 10
+      iron: 30
+      gold: 15
+      population: 1
+
+# 12. Skirmisher - Clone Sniper
+- id: rep_clone_sniper
+  display_name: Clone Sniper
+  description: Elite long-range clone sniper providing overwatch and high-value target elimination.
+  unit_class: Skirmisher
+  faction_id: republic
+  tier: 3
+  weapon: dc15x_sniper
+  vanilla_mapping: skirmisher
+  defense_tags: [InfantryArmor, Biological]
+  behavior_tags: [Kite]
+  stats:
+    hp: 65.0
+    damage: 40.0
+    armor: 2.0
+    range: 40.0
+    speed: 4.0
+    accuracy: 0.95
+    fire_rate: 0.5
+    morale: 85.0
+    cost:
+      food: 40
+      wood: 0
+      stone: 0
+      iron: 30
+      gold: 35
+      population: 1
+
+# 13. Special - Clone Commando
+- id: rep_clone_commando
+  display_name: Clone Commando
+  description: Republic Commando squad, elite special forces with versatile DC-17m weapon system.
+  unit_class: ShieldedElite
+  faction_id: republic
+  tier: 3
+  weapon: dc17m_anti_armor
+  vanilla_mapping: special
+  defense_tags: [HeavyArmor, Biological]
+  behavior_tags: [AdvanceFire, AntiArmor]
+  stats:
+    hp: 200.0
+    damage: 55.0
+    armor: 12.0
+    range: 22.0
+    speed: 5.0
+    accuracy: 0.85
+    fire_rate: 0.3
+    morale: 130.0
+    cost:
+      food: 70
+      wood: 0
+      stone: 0
+      iron: 60
+      gold: 55
+      population: 2

--- a/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/waves/clone_wars_waves.yaml
+++ b/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/waves/clone_wars_waves.yaml
@@ -1,0 +1,257 @@
+# Clone Wars Campaign Waves
+# 10 waves of CIS droid assault escalation
+
+- id: cw_wave_01
+  display_name: "Wave 1 - Droid Scouts"
+  description: Initial probe with B1 droids and probe droids.
+  wave_number: 1
+  delay_seconds: 120.0
+  is_final_wave: false
+  spawn_groups:
+    - unit_id: cis_b1_battle_droid
+      count: 30
+      spawn_delay: 0.3
+    - unit_id: cis_probe_droid
+      count: 5
+      spawn_delay: 1.0
+  difficulty_scaling:
+    count_multiplier: 1.0
+    health_multiplier: 1.0
+    damage_multiplier: 1.0
+
+- id: cw_wave_02
+  display_name: "Wave 2 - Droid Advance"
+  description: B1 squads push forward with coordinated fire.
+  wave_number: 2
+  delay_seconds: 180.0
+  is_final_wave: false
+  spawn_groups:
+    - unit_id: cis_b1_battle_droid
+      count: 50
+      spawn_delay: 0.2
+    - unit_id: cis_b1_squad
+      count: 20
+      spawn_delay: 0.4
+  difficulty_scaling:
+    count_multiplier: 1.1
+    health_multiplier: 1.0
+    damage_multiplier: 1.0
+
+- id: cw_wave_03
+  display_name: "Wave 3 - Heavy Metal"
+  description: B2 Super Battle Droids join the assault.
+  wave_number: 3
+  delay_seconds: 240.0
+  is_final_wave: false
+  spawn_groups:
+    - unit_id: cis_b1_battle_droid
+      count: 60
+      spawn_delay: 0.2
+    - unit_id: cis_b1_squad
+      count: 25
+      spawn_delay: 0.3
+    - unit_id: cis_b2_super_battle_droid
+      count: 8
+      spawn_delay: 1.0
+  difficulty_scaling:
+    count_multiplier: 1.1
+    health_multiplier: 1.05
+    damage_multiplier: 1.0
+
+- id: cw_wave_04
+  display_name: "Wave 4 - Speeder Rush"
+  description: STAP riders flank while main force advances.
+  wave_number: 4
+  delay_seconds: 300.0
+  is_final_wave: false
+  spawn_groups:
+    - unit_id: cis_b1_battle_droid
+      count: 80
+      spawn_delay: 0.15
+    - unit_id: cis_b1_squad
+      count: 30
+      spawn_delay: 0.3
+    - unit_id: cis_stap_pilot
+      count: 10
+      spawn_delay: 0.8
+    - unit_id: cis_medical_droid
+      count: 3
+      spawn_delay: 2.0
+  difficulty_scaling:
+    count_multiplier: 1.2
+    health_multiplier: 1.1
+    damage_multiplier: 1.05
+
+- id: cw_wave_05
+  display_name: "Wave 5 - Armor Column"
+  description: AATs roll in with heavy fire support.
+  wave_number: 5
+  delay_seconds: 360.0
+  is_final_wave: false
+  spawn_groups:
+    - unit_id: cis_b1_squad
+      count: 40
+      spawn_delay: 0.2
+    - unit_id: cis_b2_super_battle_droid
+      count: 15
+      spawn_delay: 0.6
+    - unit_id: cis_aat_crew
+      count: 3
+      spawn_delay: 3.0
+    - unit_id: cis_sniper_droid
+      count: 5
+      spawn_delay: 1.5
+  difficulty_scaling:
+    count_multiplier: 1.2
+    health_multiplier: 1.1
+    damage_multiplier: 1.1
+
+- id: cw_wave_06
+  display_name: "Wave 6 - Destroyer Shield"
+  description: Droidekas roll into position with devastating firepower.
+  wave_number: 6
+  delay_seconds: 420.0
+  is_final_wave: false
+  spawn_groups:
+    - unit_id: cis_b1_battle_droid
+      count: 100
+      spawn_delay: 0.1
+    - unit_id: cis_b2_super_battle_droid
+      count: 15
+      spawn_delay: 0.5
+    - unit_id: cis_droideka
+      count: 5
+      spawn_delay: 2.0
+    - unit_id: cis_dwarf_spider_droid
+      count: 4
+      spawn_delay: 2.0
+  difficulty_scaling:
+    count_multiplier: 1.3
+    health_multiplier: 1.15
+    damage_multiplier: 1.1
+
+- id: cw_wave_07
+  display_name: "Wave 7 - Commando Strike"
+  description: BX commando droids lead an elite assault.
+  wave_number: 7
+  delay_seconds: 480.0
+  is_final_wave: false
+  spawn_groups:
+    - unit_id: cis_b1_squad
+      count: 50
+      spawn_delay: 0.2
+    - unit_id: cis_b2_super_battle_droid
+      count: 20
+      spawn_delay: 0.4
+    - unit_id: cis_bx_commando_droid
+      count: 10
+      spawn_delay: 0.8
+    - unit_id: cis_aat_crew
+      count: 4
+      spawn_delay: 2.5
+    - unit_id: cis_magnaguard
+      count: 3
+      spawn_delay: 2.0
+  difficulty_scaling:
+    count_multiplier: 1.3
+    health_multiplier: 1.2
+    damage_multiplier: 1.15
+
+- id: cw_wave_08
+  display_name: "Wave 8 - Full Assault"
+  description: Combined droid army with all unit types deployed.
+  wave_number: 8
+  delay_seconds: 540.0
+  is_final_wave: false
+  spawn_groups:
+    - unit_id: cis_b1_battle_droid
+      count: 150
+      spawn_delay: 0.1
+    - unit_id: cis_b1_squad
+      count: 60
+      spawn_delay: 0.2
+    - unit_id: cis_b2_super_battle_droid
+      count: 20
+      spawn_delay: 0.4
+    - unit_id: cis_stap_pilot
+      count: 8
+      spawn_delay: 1.0
+    - unit_id: cis_aat_crew
+      count: 5
+      spawn_delay: 2.0
+    - unit_id: cis_droideka
+      count: 6
+      spawn_delay: 1.5
+  difficulty_scaling:
+    count_multiplier: 1.4
+    health_multiplier: 1.25
+    damage_multiplier: 1.2
+
+- id: cw_wave_09
+  display_name: "Wave 9 - Grievous Arrives"
+  description: General Grievous leads his MagnaGuard elite in a devastating strike.
+  wave_number: 9
+  delay_seconds: 600.0
+  is_final_wave: false
+  spawn_groups:
+    - unit_id: cis_b1_squad
+      count: 80
+      spawn_delay: 0.15
+    - unit_id: cis_b2_super_battle_droid
+      count: 25
+      spawn_delay: 0.3
+    - unit_id: cis_bx_commando_droid
+      count: 12
+      spawn_delay: 0.6
+    - unit_id: cis_magnaguard
+      count: 6
+      spawn_delay: 1.0
+    - unit_id: cis_general_grievous
+      count: 1
+      spawn_delay: 0.0
+    - unit_id: cis_aat_crew
+      count: 6
+      spawn_delay: 2.0
+  difficulty_scaling:
+    count_multiplier: 1.5
+    health_multiplier: 1.3
+    damage_multiplier: 1.25
+
+- id: cw_wave_10
+  display_name: "Wave 10 - Total Annihilation"
+  description: The entire Separatist army converges for the final push.
+  wave_number: 10
+  delay_seconds: 660.0
+  is_final_wave: true
+  spawn_groups:
+    - unit_id: cis_b1_battle_droid
+      count: 250
+      spawn_delay: 0.05
+    - unit_id: cis_b1_squad
+      count: 100
+      spawn_delay: 0.1
+    - unit_id: cis_b2_super_battle_droid
+      count: 40
+      spawn_delay: 0.2
+    - unit_id: cis_bx_commando_droid
+      count: 15
+      spawn_delay: 0.5
+    - unit_id: cis_droideka
+      count: 10
+      spawn_delay: 1.0
+    - unit_id: cis_dwarf_spider_droid
+      count: 8
+      spawn_delay: 1.0
+    - unit_id: cis_aat_crew
+      count: 8
+      spawn_delay: 1.5
+    - unit_id: cis_magnaguard
+      count: 8
+      spawn_delay: 1.0
+    - unit_id: cis_general_grievous
+      count: 1
+      spawn_delay: 0.0
+  difficulty_scaling:
+    count_multiplier: 1.5
+    health_multiplier: 1.4
+    damage_multiplier: 1.3

--- a/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/weapons/blasters.yaml
+++ b/packs/community-contributions/dinoforge-packs-mirror/warfare-starwars/weapons/blasters.yaml
@@ -1,0 +1,167 @@
+# Star Wars Weapons - Blasters, Lightsabers, Heavy Ordnance
+
+# --- Republic Weapons ---
+
+- id: dc15a_blaster
+  display_name: DC-15A Blaster Rifle
+  weapon_class: rifle
+  damage_type: energy
+  base_damage: 14.0
+  range: 20.0
+  rate_of_fire: 2.5
+  aoe_radius: 0.0
+
+- id: dc15s_carbine
+  display_name: DC-15S Blaster Carbine
+  weapon_class: rifle
+  damage_type: energy
+  base_damage: 10.0
+  range: 16.0
+  rate_of_fire: 4.0
+  aoe_radius: 0.0
+
+- id: dc17_pistol
+  display_name: DC-17 Hand Blaster
+  weapon_class: rifle
+  damage_type: energy
+  base_damage: 8.0
+  range: 12.0
+  rate_of_fire: 3.0
+  aoe_radius: 0.0
+
+- id: z6_rotary_cannon
+  display_name: Z-6 Rotary Blaster Cannon
+  weapon_class: rifle
+  damage_type: energy
+  base_damage: 10.0
+  range: 18.0
+  rate_of_fire: 8.0
+  aoe_radius: 0.0
+
+- id: dc15x_sniper
+  display_name: DC-15x Sniper Rifle
+  weapon_class: rifle
+  damage_type: energy
+  base_damage: 40.0
+  range: 40.0
+  rate_of_fire: 0.5
+  aoe_radius: 0.0
+
+- id: atte_mass_driver
+  display_name: AT-TE Mass Driver Cannon
+  weapon_class: cannon
+  damage_type: explosive
+  base_damage: 65.0
+  range: 40.0
+  rate_of_fire: 0.2
+  aoe_radius: 5.0
+
+- id: lightsaber
+  display_name: Lightsaber
+  weapon_class: melee
+  damage_type: energy
+  base_damage: 50.0
+  range: 2.0
+  rate_of_fire: 2.5
+  aoe_radius: 0.0
+
+- id: dc17m_sniper
+  display_name: DC-17m Sniper Attachment
+  weapon_class: rifle
+  damage_type: energy
+  base_damage: 35.0
+  range: 35.0
+  rate_of_fire: 0.8
+  aoe_radius: 0.0
+
+- id: dc17m_anti_armor
+  display_name: DC-17m Anti-Armor Attachment
+  weapon_class: missile
+  damage_type: explosive
+  base_damage: 55.0
+  range: 22.0
+  rate_of_fire: 0.3
+  aoe_radius: 3.0
+
+# --- CIS Weapons ---
+
+- id: e5_blaster
+  display_name: E-5 Blaster Rifle
+  weapon_class: rifle
+  damage_type: energy
+  base_damage: 9.0
+  range: 16.0
+  rate_of_fire: 3.0
+  aoe_radius: 0.0
+
+- id: wrist_blaster
+  display_name: Wrist-Mounted Blaster
+  weapon_class: rifle
+  damage_type: energy
+  base_damage: 14.0
+  range: 18.0
+  rate_of_fire: 4.0
+  aoe_radius: 0.0
+
+- id: e5s_sniper
+  display_name: E-5s Sniper Rifle
+  weapon_class: rifle
+  damage_type: energy
+  base_damage: 30.0
+  range: 35.0
+  rate_of_fire: 0.6
+  aoe_radius: 0.0
+
+- id: stap_blaster
+  display_name: STAP Twin Blasters
+  weapon_class: rifle
+  damage_type: energy
+  base_damage: 10.0
+  range: 18.0
+  rate_of_fire: 6.0
+  aoe_radius: 0.0
+
+- id: aat_cannon
+  display_name: AAT Heavy Laser Cannon
+  weapon_class: cannon
+  damage_type: explosive
+  base_damage: 55.0
+  range: 35.0
+  rate_of_fire: 0.25
+  aoe_radius: 4.0
+
+- id: droideka_blasters
+  display_name: Droideka Twin Blasters
+  weapon_class: rifle
+  damage_type: energy
+  base_damage: 12.0
+  range: 20.0
+  rate_of_fire: 10.0
+  aoe_radius: 0.0
+
+- id: dwarf_spider_cannon
+  display_name: DSD1 Laser Cannon
+  weapon_class: cannon
+  damage_type: energy
+  base_damage: 35.0
+  range: 30.0
+  rate_of_fire: 0.5
+  aoe_radius: 2.0
+
+- id: grievous_lightsabers
+  display_name: "Grievous's Lightsabers"
+  weapon_class: melee
+  damage_type: energy
+  base_damage: 60.0
+  range: 2.5
+  rate_of_fire: 4.0
+  aoe_radius: 0.0
+
+- id: electrostaff
+  display_name: Electrostaff
+  weapon_class: melee
+  damage_type: energy
+  base_damage: 30.0
+  range: 2.0
+  rate_of_fire: 2.0
+  aoe_radius: 0.0

--- a/packs/example-balance/buildings/barracks.yaml
+++ b/packs/example-balance/buildings/barracks.yaml
@@ -1,0 +1,18 @@
+# Barracks - primary unit production building
+id: barracks
+display_name: Barracks
+description: Trains and musters infantry units for the defense.
+building_type: barracks
+
+cost:
+  food: 0
+  wood: 50
+  stone: 30
+  iron: 10
+  gold: 0
+  population: 0
+
+health: 500
+
+production:
+  militia: 1

--- a/packs/example-balance/factions/defenders.yaml
+++ b/packs/example-balance/factions/defenders.yaml
@@ -1,0 +1,30 @@
+# Defenders - a simple defensive faction
+faction:
+  id: defenders
+  display_name: The Defenders
+  description: A stalwart faction focused on holding the line against overwhelming odds.
+  theme: fantasy
+  archetype: order
+  doctrine: elite_discipline
+
+economy:
+  gather_bonus: 1.0
+  upkeep_modifier: 0.9
+  research_speed: 1.0
+  build_speed: 1.1
+
+army:
+  morale_style: disciplined
+  unit_cap_modifier: 1.0
+  elite_cost_modifier: 1.0
+  spawn_rate_modifier: 1.0
+
+roster:
+  cheap_infantry: militia
+
+buildings:
+  barracks: barracks
+
+visuals:
+  primary_color: "#336699"
+  accent_color: "#FFCC00"

--- a/packs/example-balance/pack.yaml
+++ b/packs/example-balance/pack.yaml
@@ -1,0 +1,35 @@
+# Example Balance Pack
+# Demonstrates a content pack with units, buildings, and a faction
+
+id: example-balance-tweak
+name: Example Balance Tweak
+version: 0.1.0
+framework_version: ">=0.1.0 <1.0.0"
+author: DINOForge Examples
+type: content
+description: |
+  A minimal example pack demonstrating the DINOForge content pack pipeline and architecture.
+
+  This pack serves as a reference implementation for new modders, showcasing:
+  - Basic unit definition with stats, costs, and behavior tags
+  - Faction roster system with unit assignments and economy modifiers
+  - Building registration and faction integration
+  - Pack dependencies and manifest structure
+
+  Content includes:
+  - 1 faction: The Defenders (order archetype with elite discipline doctrine)
+  - 1 unit: Town Militia (affordable infantry for early game)
+  - 1 building: Barracks (infantry training facility)
+
+  Perfect for learning the SDK and understanding how to structure your own balance mods.
+
+depends_on: []
+conflicts_with: []
+
+loads:
+  units:
+    - units
+  buildings:
+    - buildings
+  factions:
+    - factions

--- a/packs/example-balance/stats/melee-buff.yaml
+++ b/packs/example-balance/stats/melee-buff.yaml
@@ -1,0 +1,9 @@
+overrides:
+  - target: unit.stats.hp
+    value: 1.5
+    mode: multiply
+    filter: Components.MeleeUnit
+  - target: unit.stats.speed
+    value: 1.2
+    mode: multiply
+    filter: Components.MeleeUnit

--- a/packs/example-balance/units/militia.yaml
+++ b/packs/example-balance/units/militia.yaml
@@ -1,0 +1,31 @@
+# Militia - cheap early-game infantry unit
+id: militia
+display_name: Town Militia
+description: Lightly armed citizens called to defend the settlement.
+unit_class: MilitiaLight
+faction_id: defenders
+tier: 1
+
+stats:
+  hp: 50
+  damage: 8
+  armor: 1
+  range: 0
+  speed: 3.5
+  accuracy: 0.5
+  fire_rate: 1.0
+  morale: 60
+  cost:
+    food: 20
+    wood: 5
+    stone: 0
+    iron: 0
+    gold: 0
+    population: 1
+
+defense_tags:
+  - Unarmored
+  - Biological
+
+behavior_tags:
+  - HoldLine

--- a/tests/packs/dinoforge-packs_smoke_test.go
+++ b/tests/packs/dinoforge-packs_smoke_test.go
@@ -1,0 +1,14 @@
+package smoke_test
+
+import (
+	"testing"
+)
+
+// Traces to: FR-001
+func TestPackageImports(t *testing.T) {
+	t.Log("Package import smoke test")
+	// Basic sanity check: if the package imports, the test passes
+	if true {
+		t.Log("PASS: Package imports successfully")
+	}
+}


### PR DESCRIPTION
## **User description**
## Summary

Absorbs `KooshaPari/dinoforge-packs` into `KooshaPari/Dino/packs/` per kilo audit #144 (PRESERVE → ABSORBED) and ADR-023.

## What's integrated

- `packs/example-balance/` — NEW pack (was missing from Dino)
- `packs/community-contributions/dinoforge-packs-mirror/` — snapshot of source repo, including docs/journeys, docs/operations, docs/sessions, docs/worklogs
- `tests/packs/dinoforge-packs_smoke_test.go` — Go smoke test from source
- `docs/dinoforge-packs-{AGENTS,CLAUDE,FUNCTIONAL_REQUIREMENTS,CHANGELOG}.md` — governance docs preserved
- `docs/dinoforge-packs-absorption.md` — full absorption matrix + ID divergence doc

## CRITICAL: ID divergence

The mirrored warfare-starwars manifest uses **legacy non-namespaced unit IDs** (e.g. `clone-trooper`, `b1-battle-droid`, `droideka`) that **DO NOT EXIST** in the canonical Dino `packs/warfare-starwars/` pack (which uses faction-namespaced IDs like `rep_clone_trooper`, `cis_b1_droid`, `cis_droideka`).

The mirrored manifest is preserved as historical reference and migration source. **It MUST NOT be loaded directly.** The migration path is documented in `docs/dinoforge-packs-absorption.md`.

## Why community-contributions/ subdirectory

Dino already has `packs/warfare-starwars/` (canonical, v0.5.0+) and `packs/warfare-modern/`. Adding a parallel warfare-starwars from dinoforge-packs would create an ID collision at load time. The `community-contributions/` namespace isolates stale content while preserving it for migration.

## Post-merge

Archive `KooshaPari/dinoforge-packs` (gh token lacks `delete_repo` scope). The 4 manual `gh repo delete` commands are documented in the migration notes.


___

## **CodeAnt-AI Description**
**Absorb `dinoforge-packs` into Dino and add a new example balance pack**

### What Changed
- Added `packs/example-balance/` with a simple faction, unit, building, and stat tweak example for new pack authors
- Preserved the absorbed `dinoforge-packs` content under `packs/community-contributions/dinoforge-packs-mirror/`, including the Star Wars warfare pack, docs, and governance files
- Added absorption notes and community-contributions guidance, including a warning that the mirrored Star Wars pack uses legacy unit IDs and must not be loaded directly
- Added a basic smoke test and functional requirements document for the absorbed pack set

### Impact
`✅ New pack content available in Dino`
`✅ Safer reuse of absorbed community packs`
`✅ Clearer migration path for the Star Wars pack`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
