### PR TITLE
fix(dino): screenshot targets game window first (not desktop/Parsec)

### DIFF
--- a/src/Runtime/packages.lock.json
+++ b/src/Runtime/packages.lock.json
@@ -2,6 +2,27 @@
   "version": 1,
   "dependencies": {
     ".NETStandard,Version=v2.0": {
+      "AssetsTools.NET": {
+        "type": "Direct",
+        "requested": "[3.0.4, )",
+        "resolved": "3.0.4",
+        "contentHash": "NqYy5UIucwKwdkpamFTi8lr53hD+V8qQmbHzztQj1v4Pq1G4TjNlpkUWOhktTLBqBm4aPRaAkpFgB+3TDEuomw=="
+      },
+      "BepInEx.AssemblyPublicizer.MSBuild": {
+        "type": "Direct",
+        "requested": "[0.4.3, )",
+        "resolved": "0.4.3",
+        "contentHash": "Z8Qs3JTTHZG1q0DCqY+HFJ8xp92tkEXWyQ7roeWgUvn20tjv0ZNfAdyy13XrRS1jeEoN/weJc81747TbvvwaDg=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "f5Kr5JepAbiGo7uDmhgvMqhntwxqXNn6/IpTBSSI4cuHhgnJGrLxFRhMjVpRkLPp6zJXO0/G0l3j9p9zSJxa+w==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
+        }
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -20,11 +41,6 @@
         "dependencies": {
           "Microsoft.NETCore.Platforms": "1.1.0"
         }
-      },
-      "AssetsTools.NET": {
-        "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "NqYy5UIucwKwdkpamFTi8lr53hD+V8qQmbHzztQj1v4Pq1G4TjNlpkUWOhktTLBqBm4aPRaAkpFgB+3TDEuomw=="
       },
       "es6numberserializer": {
         "type": "Transitive",
@@ -45,14 +61,6 @@
         "contentHash": "Aq7M8lG6BrHeatqKqncVm9m55ec34k6nnfPRLe/PvGg+b/pAsRM2ejofeKmCLjTXMa+5NGXm382f8CG/D5WDow==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.6.3"
-        }
-      },
-      "Microsoft.Bcl.TimeProvider": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "f5Kr5JepAbiGo7uDmhgvMqhntwxqXNn6/IpTBSSI4cuHhgnJGrLxFRhMjVpRkLPp6zJXO0/G0l3j9p9zSJxa+w==",
-        "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0"
         }
       },
       "Microsoft.Build.Tasks.Git": {
@@ -487,6 +495,24 @@
       }
     },
     "net8.0": {
+      "AssetsTools.NET": {
+        "type": "Direct",
+        "requested": "[3.0.4, )",
+        "resolved": "3.0.4",
+        "contentHash": "NqYy5UIucwKwdkpamFTi8lr53hD+V8qQmbHzztQj1v4Pq1G4TjNlpkUWOhktTLBqBm4aPRaAkpFgB+3TDEuomw=="
+      },
+      "BepInEx.AssemblyPublicizer.MSBuild": {
+        "type": "Direct",
+        "requested": "[0.4.3, )",
+        "resolved": "0.4.3",
+        "contentHash": "Z8Qs3JTTHZG1q0DCqY+HFJ8xp92tkEXWyQ7roeWgUvn20tjv0ZNfAdyy13XrRS1jeEoN/weJc81747TbvvwaDg=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "f5Kr5JepAbiGo7uDmhgvMqhntwxqXNn6/IpTBSSI4cuHhgnJGrLxFRhMjVpRkLPp6zJXO0/G0l3j9p9zSJxa+w=="
+      },
       "Microsoft.SourceLink.GitHub": {
         "type": "Direct",
         "requested": "[8.0.0, )",
@@ -496,11 +522,6 @@
           "Microsoft.Build.Tasks.Git": "8.0.0",
           "Microsoft.SourceLink.Common": "8.0.0"
         }
-      },
-      "AssetsTools.NET": {
-        "type": "Transitive",
-        "resolved": "3.0.4",
-        "contentHash": "NqYy5UIucwKwdkpamFTi8lr53hD+V8qQmbHzztQj1v4Pq1G4TjNlpkUWOhktTLBqBm4aPRaAkpFgB+3TDEuomw=="
       },
       "es6numberserializer": {
         "type": "Transitive",
@@ -514,11 +535,6 @@
         "dependencies": {
           "es6numberserializer": "1.0.0"
         }
-      },
-      "Microsoft.Bcl.TimeProvider": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "f5Kr5JepAbiGo7uDmhgvMqhntwxqXNn6/IpTBSSI4cuHhgnJGrLxFRhMjVpRkLPp6zJXO0/G0l3j9p9zSJxa+w=="
       },
       "Microsoft.Build.Tasks.Git": {
         "type": "Transitive",

--- a/src/Tools/McpServer/Tools/GameCaptureHelper.cs
+++ b/src/Tools/McpServer/Tools/GameCaptureHelper.cs
@@ -14,9 +14,9 @@ namespace DINOForge.Tools.McpServer.Tools;
 /// 1. PlayCUA (playcua-native) — GPU-accelerated, if available
 /// 2. bare-cua-native — fast native capture via JSON-RPC
 /// 3. Unity ScreenCapture.CaptureScreenshot() via file-signal — works on Parsec/virtual displays
-/// 4. ScreenCapture.NET DXGI Desktop Duplication — works for exclusive DX11 fullscreen on physical displays
-/// 5. ScreenRecorderLib (Windows.Graphics.Capture) — per-window capture fallback
-/// 6. ffmpeg gdigrab — GDI desktop capture (last resort, fails on Parsec)
+/// 4. ScreenRecorderLib (Windows.Graphics.Capture) — WINDOW-TARGETED per-window capture (game window only)
+/// 5. ScreenCapture.NET DXGI Desktop Duplication — whole-desktop fallback (only if no game window found)
+/// 6. ffmpeg gdigrab — whole-desktop GDI capture (last resort, fails on Parsec)
 /// </summary>
 internal static class GameCaptureHelper
 {
@@ -32,7 +32,7 @@ internal static class GameCaptureHelper
 
     /// <summary>
     /// Captures the game window to a PNG file. Returns the output path on success, null on failure.
-    /// Cascade: PlayCUA → bare-cua → Unity ScreenCapture → DXGI → ScreenRecorderLib → ffmpeg gdigrab.
+    /// Cascade: PlayCUA → bare-cua → Unity ScreenCapture → ScreenRecorderLib (window-targeted) → DXGI → ffmpeg gdigrab (desktop fallbacks).
     /// </summary>
     internal static async Task<string?> CaptureAsync(string outputPath, CancellationToken ct = default)
     {
@@ -55,15 +55,20 @@ internal static class GameCaptureHelper
         if (await TryUnityScreenCaptureAsync(safeOutputPath, ct).ConfigureAwait(false))
             return safeOutputPath;
 
-        // Quaternary: DXGI Desktop Duplication (works for exclusive DX11 on physical displays)
-        if (OperatingSystem.IsWindows() && await TryDxgiCaptureAsync(safeOutputPath, ct).ConfigureAwait(false))
-            return safeOutputPath;
-
-        // Quinary: Windows.Graphics.Capture via ScreenRecorderLib
+        // Quaternary: Windows.Graphics.Capture via ScreenRecorderLib — WINDOW-TARGETED.
+        // Tried BEFORE any whole-desktop tier so we grab the game window, not the user's
+        // desktop / Parsec VDD. Returns false (falls through) if the game window isn't found.
         if (await TryScreenRecorderLibAsync(safeOutputPath, ct).ConfigureAwait(false))
             return safeOutputPath;
 
-        // Last resort: ffmpeg gdigrab
+        // Whole-desktop fallbacks below — only reached when no game window could be located
+        // for window-targeted capture (e.g. exclusive DX11 fullscreen with no Win32 window).
+
+        // Quinary: DXGI Desktop Duplication (works for exclusive DX11 on physical displays)
+        if (OperatingSystem.IsWindows() && await TryDxgiCaptureAsync(safeOutputPath, ct).ConfigureAwait(false))
+            return safeOutputPath;
+
+        // Last resort: ffmpeg gdigrab (whole desktop)
         if (await TryFfmpegGdigrabAsync(safeOutputPath, ct).ConfigureAwait(false))
             return safeOutputPath;
 


### PR DESCRIPTION
## **User description**
GameCaptureHelper cascade tried whole-desktop DXGI before the window-targeted ScreenRecorderLib tier -> grabbed the user's Parsec VDD instead of the game (audit's core no-sponsor-validation blocker). Reordered so window-targeted MainWindowHandle capture runs FIRST; desktop tiers (DXGI, gdigrab) only as fallback when the window can't be found. Build exit-0. Python FastMCP server uses a separate window-targeted WGC path (capture_window by title) and does NOT share this helper. Runtime SSIM proof pending (needs game launch via game_launch).


___

## **CodeAnt-AI Description**
**Capture the game window instead of the desktop when taking screenshots**

### What Changed
- Window-based capture now runs before desktop-wide fallback capture, so screenshots are taken from the game window first instead of the user’s desktop or Parsec display
- If the game window cannot be found, the app falls back to desktop capture methods
- Package lock updates were refreshed to match the current dependency set

### Impact
`✅ Fewer wrong-window screenshots`
`✅ Less chance of capturing Parsec or the desktop instead of the game`
`✅ More reliable screenshot capture in fullscreen and virtual-display setups`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
