### PR TITLE
fix(dino): packs dir resolves to running game dir (fixes asset swaps 0 changes)

### DIFF
--- a/src/Runtime/ModPlatform.cs
+++ b/src/Runtime/ModPlatform.cs
@@ -217,10 +217,34 @@ namespace DINOForge.Runtime
             // Bind config entries
             try
             {
+                // Default + canonical packs directory is ALWAYS derived from the
+                // running plugin's BepInEx root (Paths.BepInExRootPath = the actually
+                // running game install), never a hardcoded/MAIN install path.
+                string runningPacksDir = Path.Combine(Paths.BepInExRootPath, "dinoforge_packs");
+
                 _packsDirectory = _config.Bind(
                     "Packs", "PacksDirectory",
-                    Path.Combine(Paths.BepInExRootPath, "dinoforge_packs"),
+                    runningPacksDir,
                     "Directory containing DINOForge content packs");
+
+                // A previously-persisted config (e.g. copied/deployed from the MAIN
+                // install) can pin PacksDirectory to a path that does NOT belong to the
+                // running install. That yields DirectoryNotFoundException -> packs=0 ->
+                // "asset swaps 0 changes". If the configured value isn't the running
+                // install's packs dir AND doesn't exist on disk, re-anchor it to the
+                // running BepInEx root so packs load relative to the launched exe.
+                string configuredPacksDir = _packsDirectory.Value;
+                bool isRunningRoot = string.Equals(
+                    Path.GetFullPath(configuredPacksDir).TrimEnd(Path.DirectorySeparatorChar),
+                    Path.GetFullPath(runningPacksDir).TrimEnd(Path.DirectorySeparatorChar),
+                    StringComparison.OrdinalIgnoreCase);
+                if (!isRunningRoot && !Directory.Exists(configuredPacksDir))
+                {
+                    _log.LogWarning(
+                        $"[ModPlatform] Configured PacksDirectory '{configuredPacksDir}' does not exist and is not the running install's packs dir; " +
+                        $"re-anchoring to running BepInEx root '{runningPacksDir}'.");
+                    _packsDirectory.Value = runningPacksDir;
+                }
 
                 _autoLoadOnStartup = _config.Bind(
                     "Packs", "AutoLoadOnStartup",


### PR DESCRIPTION
## **User description**
In-game inject-smoke proved injection+load work, but a persisted config could pin the packs dir to the MAIN install path (not the running exe) -> DirectoryNotFoundException -> packs=0 -> asset swaps no-op (the user's #1 symptom). ModPlatform now derives the canonical packs dir from BepInEx Paths.BepInExRootPath (the running install) and re-anchors any stale/non-existent configured path that isn't the running install's packs dir. Default is running-exe-relative; explicit valid overrides are preserved. Build exit-0 (Release, 0 errors).


___

## **CodeAnt-AI Description**
**Use the running game’s packs folder when loading content packs**

### What Changed
- The packs folder now defaults to the directory next to the game that is currently running, instead of staying tied to a copied or older install path.
- If a saved packs path points to a folder that no longer exists and does not match the running game’s packs folder, the game now switches back to the correct location and logs a warning.
- This prevents packs from loading as zero and stops asset swaps from silently doing nothing.

### Impact
`✅ Fewer asset swap failures`
`✅ Packs load from the launched game install`
`✅ Fewer broken starts after moving or copying the game`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
