### PR TITLE
fix(dino): packs re-anchor to running install (verified in-game packs>0)

### DIFF
--- a/src/Runtime/ModPlatform.cs
+++ b/src/Runtime/ModPlatform.cs
@@ -222,6 +222,23 @@ namespace DINOForge.Runtime
                     Path.Combine(Paths.BepInExRootPath, "dinoforge_packs"),
                     "Directory containing DINOForge content packs");
 
+                // Re-anchor: a persisted config value can pin an absolute path from a
+                // DIFFERENT install (e.g. MAIN game dir copied into a _TEST variant),
+                // causing DirectoryNotFound -> packs=0. If the bound dir isn't under the
+                // RUNNING install root, or doesn't exist, force it to the running-relative
+                // default so packs always resolve against the actually-running game.
+                {
+                    string runningDefault = Path.Combine(Paths.BepInExRootPath, "dinoforge_packs");
+                    string current = _packsDirectory.Value ?? string.Empty;
+                    bool underRunningRoot = !string.IsNullOrEmpty(current)
+                        && current.StartsWith(Paths.BepInExRootPath, StringComparison.OrdinalIgnoreCase);
+                    if (!underRunningRoot || !Directory.Exists(current))
+                    {
+                        _log.LogWarning($"[ModPlatform] PacksDirectory '{current}' is not under the running install root or does not exist; re-anchoring to '{runningDefault}'.");
+                        _packsDirectory.Value = runningDefault;
+                    }
+                }
+
                 _autoLoadOnStartup = _config.Bind(
                     "Packs", "AutoLoadOnStartup",
                     true,


### PR DESCRIPTION
## **User description**
Root cause (in-game verified): BepInEx config persisted PacksDirectory=MAIN-install path; _config.Bind returns the persisted value, so _TEST used MAIN -> DirectoryNotFound -> packs=0 (asset swaps no-op). Fix: after Bind, if PacksDirectory isn't under the running Paths.BepInExRootPath or doesn't exist, reset to running default. VERIFIED IN-GAME (_TEST hidden): re-anchor warning fired, packs=10, path=_TEST, no DirectoryNotFound. #319 was rejected (verified still packs=0).


___

## **CodeAnt-AI Description**
Re-anchor packs to the current game install when a saved path is stale

### What Changed
- If the saved packs folder points to a different install or no longer exists, the game now switches back to the current install’s default packs folder
- This prevents packs from loading as zero when a copied or renamed install keeps an old path in settings
- A warning is shown when the packs folder is corrected so the issue is visible in logs

### Impact
`✅ Fewer missing packs after copying or moving an install`
`✅ Fewer "packs=0" startup failures`
`✅ Clearer recovery from stale pack paths`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
