### PR TITLE
fix(dino): launch ensures Steam running (fixes loading-skeleton hang)

### DIFF
--- a/src/Tools/McpServer/GameProcessManager.cs
+++ b/src/Tools/McpServer/GameProcessManager.cs
@@ -51,6 +51,8 @@ public sealed class GameProcessManager : IDisposable
         if (!File.Exists(exePath))
             return false;
 
+        EnsureSteamRunning();
+
         var psi = new ProcessStartInfo(exePath)
         {
             WorkingDirectory = _testInstancePath,
@@ -102,6 +104,8 @@ public sealed class GameProcessManager : IDisposable
 
         if (string.IsNullOrEmpty(exePath) || !File.Exists(exePath))
             return false;
+
+        EnsureSteamRunning();
 
         var psi = new ProcessStartInfo(exePath)
         {
@@ -181,6 +185,55 @@ public sealed class GameProcessManager : IDisposable
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Ensures the Steam client is running before launching the game.
+    /// DINO's main-menu news/profile/leaderboard panels depend on a successful
+    /// SteamAPI_Init; if the Steam client is not running those panels hang as
+    /// loading skeletons. Launching the Steam client first (steam_appid.txt still
+    /// keeps DINO from self-relaunching) lets SteamAPI_Init succeed so the panels
+    /// populate. Windows-only; a no-op on other platforms.
+    /// </summary>
+    public static void EnsureSteamRunning()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        try
+        {
+            if (Process.GetProcessesByName("steam").Length > 0)
+                return; // already running
+
+            string[] steamExeCandidates =
+            [
+                @"C:\Program Files (x86)\Steam\steam.exe",
+                @"C:\Program Files\Steam\steam.exe",
+            ];
+
+            string? steamExe = Array.Find(steamExeCandidates, File.Exists);
+            if (steamExe is null)
+                return; // Steam not installed where we expect; let launch proceed
+
+            var steamPsi = new ProcessStartInfo(steamExe)
+            {
+                Arguments = "-silent",
+                UseShellExecute = true,
+            };
+            using Process? steam = Process.Start(steamPsi);
+
+            // Give the Steam client time to come up so SteamAPI_Init can connect.
+            for (int i = 0; i < 30; i++)
+            {
+                if (Process.GetProcessesByName("steam").Length > 0)
+                    break;
+                Thread.Sleep(1000);
+            }
+        }
+        catch
+        {
+            // safe-swallow: best-effort Steam launch; still attempt the game launch.
+        }
     }
 
     public void Dispose()


### PR DESCRIPTION
## **User description**
The 2 stuck main-menu loading skeletons (upper-right news/featured panel + center emblem) were the base-game Steam-dependent panels (news/profile/leaderboard) hanging because the game was launched with the Steam CLIENT NOT RUNNING -> SteamAPI_Init fails.

VERIFIED: with the Steam client running, launching the _TEST instance (steam_appid.txt=1272320 beside exe) populates the panels - the upper-right panel renders ship/featured content and the center emblem shows the full Clone Wars emblem with the DF core badge (no empty skeleton, no stuck spinner). Occlusion-proof PrintWindow capture confirms.

The MOD was always healthy (takeover art LOADED, packs=10, Mods button live, profile buttons wired).

Fix: GameProcessManager.EnsureSteamRunning() starts steam.exe -silent (and waits up to 30s) if the Steam client is not already running, called before both LaunchTestInstance and the default LaunchSync paths. Windows-guarded no-op elsewhere.

Build: McpServer Release exit 0.


___

## **CodeAnt-AI Description**
**Ensure Steam is running before launching the game**

### What Changed
- The game now starts Steam first when launching from the test instance or normal game path on Windows.
- This prevents the main-menu news, profile, and leaderboard panels from getting stuck on loading skeletons when Steam was not already open.
- If Steam is not installed in the expected location or cannot be started, the game launch still continues.

### Impact
`✅ Fewer stuck main-menu panels`
`✅ Clearer Steam-backed menu content`
`✅ Fewer failed launches when Steam is closed`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
