### PR TITLE
fix(asset-engine): real mesh import/decimate (was stubbed) + Mojo kernel tier

### DIFF
--- a/docs/asset-engine-mojo-plan.md
+++ b/docs/asset-engine-mojo-plan.md
@@ -1,0 +1,72 @@
+# Asset Engine — Mojo GPU-Kernel Tier (Plan)
+
+Status: **PLAN ONLY** — `mojo`/MAX not installed on this machine (verified: `mojo --version` → not found,
+`which mojo` → not found). The landed CPU fix is Rust + `meshopt` (meshoptimizer SIMD). This doc designs the
+Mojo GPU-kernel upgrade for user approval before any `modular`/MAX install.
+
+## Why this tier exists (language doctrine, locked)
+
+Split the asset-swap engine by workload:
+
+| Workload | Tier | Crate / runtime | Rationale |
+|---|---|---|---|
+| glTF/GLB parse, scene-graph aggregation, BVH build | **Rust** | `gltf`, (future) `meshopt`/`bvh` | Correctness + CPU; wrap mature crates |
+| Mesh decimation (Garland-Heckbert quadrics), skinning, batch transforms | **Mojo** | MAX + GPU | Data-parallel, GPU-shaped; beats Zig manual-SPIR-V |
+
+The old `src/Tools/AssetPipelineZig` Garland-Heckbert decimation + BVH TODO stubs are **superseded**: the CPU
+decimation path now lives in Rust (`meshopt::simplify`), and the GPU quadric-error decimation is a **Mojo
+candidate, not Zig**. Zig manual SPIR-V is not pursued.
+
+## Kernels that move to Mojo
+
+1. **Quadric-error mesh decimation (Garland-Heckbert)** — per-vertex 4x4 quadric matrices, edge-collapse cost
+   evaluation. Embarrassingly parallel over vertices/edges; GPU reduction for cost heap. (CPU fallback already
+   shipped via `meshopt::simplify`.)
+2. **Linear-blend skinning / batch transforms** — `out_v = Σ w_i · (M_i · v)` per vertex per frame. Pure SIMD/GPU.
+3. **BVH leaf-bounds + Morton-code sort** — parallel AABB reduction + radix sort for spatial index build.
+
+## Rust ↔ Mojo C-ABI boundary
+
+Mojo exports a C-ABI shared lib (`.dll`/`.so`/`.dylib`); Rust calls it via `extern "C"` (mirrors how C# calls
+Rust today). Flat POD buffers only across the boundary — no Rust/Mojo types shared.
+
+```
+// Mojo side (exported C ABI):
+//   i32 mojo_decimate_qem(
+//       const f32* positions, u64 vertex_count,   // xyz triplets
+//       const u32* indices,   u64 index_count,
+//       u64 target_index_count,
+//       u32* out_indices, u64* out_index_count)   // caller-allocated, capacity = index_count
+
+#[link(name = "dinoforge_asset_kernels")]
+extern "C" {
+    fn mojo_decimate_qem(
+        positions: *const f32, vertex_count: u64,
+        indices: *const u32, index_count: u64,
+        target_index_count: u64,
+        out_indices: *mut u32, out_index_count: *mut u64,
+    ) -> i32;
+}
+```
+
+Rust `decimate()` gains a runtime switch: if the Mojo kernel lib is present (and a GPU is available), dispatch
+to `mojo_decimate_qem`; otherwise fall back to the shipped `meshopt::simplify` CPU path. Same JSON in/out, so the
+C# Runtime and PyO3/MCP surfaces are unchanged.
+
+## MAX / GPU offload targets (user hardware)
+
+- **RTX 3090 Ti** — CUDA / DX12; primary GPU decimation + skinning target. MAX emits PTX.
+- **M1 MacBook** — Metal; MAX Metal backend. Same Mojo source, different MAX target.
+- CPU SIMD (`meshopt`) remains the universal fallback when no GPU / MAX runtime.
+
+## Install needed (USER APPROVAL REQUIRED)
+
+```
+# Modular / MAX toolchain (provides `mojo` + MAX GPU runtime):
+curl -ssL https://magic.modular.com/ | bash      # or: pixi global install modular
+modular install max
+mojo --version                                   # verify
+```
+
+Flag: **mojo/max install needed via `modular`** — not installed; deferred to user. Until then the Rust + meshopt
+CPU path is the landed, building, tested implementation.

--- a/src/Tools/AssetPipelineRust/Cargo.lock
+++ b/src/Tools/AssetPipelineRust/Cargo.lock
@@ -3,34 +3,10 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.4"
+name = "adler2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "alloca"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
-name = "anstyle"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "anyhow"
@@ -39,19 +15,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bitflags"
@@ -60,22 +33,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
-name = "bumpalo"
-version = "3.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
-
-[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
-name = "cast"
-version = "0.3.0"
+name = "byteorder"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "cc"
@@ -94,142 +67,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "ciborium"
-version = "0.2.2"
+name = "crc32fast"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
+ "cfg-if",
 ]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
-name = "clap"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
-dependencies = [
- "clap_builder",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
-dependencies = [
- "anstyle",
- "clap_lex",
-]
-
-[[package]]
-name = "clap_lex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "criterion"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
-dependencies = [
- "alloca",
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "itertools",
- "num-traits",
- "oorandom",
- "page_size",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
-dependencies = [
- "cast",
- "itertools",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "dinoforge-asset-pipeline"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
- "criterion",
- "nalgebra",
- "ndarray",
- "pyo3",
- "rayon",
+ "gltf",
+ "meshopt",
  "serde",
  "serde_json",
  "tempfile",
 ]
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -254,10 +109,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "foldhash"
@@ -279,38 +162,42 @@ dependencies = [
 ]
 
 [[package]]
-name = "glam"
-version = "0.30.10"
+name = "gltf"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fc433e8437a212d1b6f1e68c7824af3aed907da60afa994e7f542d18d12aa9"
-
-[[package]]
-name = "glam"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556f6b2ea90b8d15a74e0e7bb41671c9bdf38cd9f78c284d750b9ce58a2b5be7"
-
-[[package]]
-name = "glam"
-version = "0.32.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
-
-[[package]]
-name = "glam"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb167719045debebe9f532320accc7b5c993c5a3b813f5696a11d5ca7bdc57b"
-
-[[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+checksum = "e3ce1918195723ce6ac74e80542c5a96a40c2b26162c1957a5cd70799b8cacf7"
 dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
+ "base64",
+ "byteorder",
+ "gltf-json",
+ "image",
+ "lazy_static",
+ "serde_json",
+ "urlencoding",
+]
+
+[[package]]
+name = "gltf-derive"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14070e711538afba5d6c807edb74bcb84e5dbb9211a3bf5dea0dfab5b24f4c51"
+dependencies = [
+ "inflections",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "gltf-json"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6176f9d60a7eab0a877e8e96548605dedbde9190a7ae1e80bbcc1c9af03ab14"
+dependencies = [
+ "gltf-derive",
+ "serde",
+ "serde_derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -341,6 +228,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,13 +255,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
+name = "inflections"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
+checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
 name = "itoa"
@@ -368,14 +267,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "js-sys"
-version = "0.3.94"
+name = "lazy_static"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
-dependencies = [
- "once_cell",
- "wasm-bindgen",
-]
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -402,104 +297,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
-name = "matrixmultiply"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
-dependencies = [
- "autocfg",
- "rawpointer",
-]
-
-[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
-name = "nalgebra"
-version = "0.35.0"
+name = "meshopt"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc43a60c217b0c6ff46e47f26911015ad8d2e5a8be1af668c67e370d99a4346"
+checksum = "4b87fa02c060ffe367138c480622816cd627418bec30fec71b20725fb9ba10a5"
 dependencies = [
- "approx",
- "glam 0.30.10",
- "glam 0.31.1",
- "glam 0.32.1",
- "glam 0.33.0",
- "matrixmultiply",
- "nalgebra-macros",
- "num-complex",
- "num-rational",
- "num-traits",
- "simba",
- "typenum",
+ "bitflags",
+ "cc",
+ "float-cmp",
+ "thiserror",
 ]
 
 [[package]]
-name = "nalgebra-macros"
-version = "0.3.0"
+name = "miniz_oxide"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "973e7178a678cfd059ccec50887658d482ce16b0aa9da3888ddeab5cd5eb4889"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
-name = "ndarray"
-version = "0.17.2"
+name = "moxcms"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "portable-atomic",
- "portable-atomic-util",
- "rawpointer",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
-dependencies = [
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -518,62 +350,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "oorandom"
-version = "11.1.5"
+name = "png"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "page_size"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -596,62 +382,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "pyo3"
-version = "0.28.3"
+name = "pxfm"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
-dependencies = [
- "libc",
- "once_cell",
- "portable-atomic",
- "pyo3-build-config",
- "pyo3-ffi",
- "pyo3-macros",
-]
-
-[[package]]
-name = "pyo3-build-config"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
-dependencies = [
- "target-lexicon",
-]
-
-[[package]]
-name = "pyo3-ffi"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
-dependencies = [
- "libc",
- "pyo3-build-config",
-]
-
-[[package]]
-name = "pyo3-macros"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
-dependencies = [
- "proc-macro2",
- "pyo3-macros-backend",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pyo3-macros-backend"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
-dependencies = [
- "heck",
- "proc-macro2",
- "pyo3-build-config",
- "quote",
- "syn",
-]
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "quote"
@@ -669,61 +403,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
-
-[[package]]
-name = "rayon"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,30 +413,6 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
-]
-
-[[package]]
-name = "rustversion"
-version = "1.0.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "safe_arch"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7caad094bd561859bcd467734a720c3c1f5d1f338995351fefe2190c45efed"
-dependencies = [
- "bytemuck",
-]
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -816,16 +471,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
-name = "simba"
-version = "0.10.0"
+name = "simd-adler32"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f45c644a9f3a386f9288625d9f0c1e999e1acf07a37df35d0516c7f199d9cb2"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "wide",
-]
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "syn"
@@ -837,12 +486,6 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "target-lexicon"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -858,20 +501,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinytemplate"
-version = "1.2.1"
+name = "thiserror"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "serde",
- "serde_json",
+ "thiserror-impl",
 ]
 
 [[package]]
-name = "typenum"
-version = "1.19.0"
+name = "thiserror-impl"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -886,14 +533,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "walkdir"
-version = "2.5.0"
+name = "urlencoding"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "wasip2"
@@ -911,51 +554,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
-]
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
-dependencies = [
- "bumpalo",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
-dependencies = [
- "unicode-ident",
 ]
 
 [[package]]
@@ -991,57 +589,6 @@ dependencies = [
  "indexmap",
  "semver",
 ]
-
-[[package]]
-name = "web-sys"
-version = "0.3.94"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "wide"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7714cd0430a663154667c74da5d09325c2387695bee18b3f7f72825aa3693a"
-dependencies = [
- "bytemuck",
- "safe_arch",
-]
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -1147,27 +694,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/src/Tools/AssetPipelineRust/Cargo.toml
+++ b/src/Tools/AssetPipelineRust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dinoforge-asset-pipeline"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["DINOForge Agents"]
 license = "MIT"
@@ -9,30 +9,25 @@ description = "High-performance asset import and LOD generation for DINOForge mo
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-pyo3 = { version = "0.28", features = ["extension-module"] }
-nalgebra = "0.35"  # Linear algebra (mesh transforms, bounds)
-rayon = "1.12"  # Parallelism for LOD generation
-ndarray = "0.17"  # Array operations (SIMD-compatible)
-# assimp removed: requires C++ build tools and CMake. Will be wrapped in future via AssetPipeline DLL
+# Mesh I/O + scene-graph (Rust tier: correctness, CPU). Wrap, don't handroll.
+gltf = { version = "1.4", features = ["import", "utils"] }
+# Industry-standard meshoptimizer bindings: SIMD CPU decimation (LOD). CPU path; Mojo-GPU is the upgrade.
+meshopt = "0.4"
 
 [dev-dependencies]
-criterion = "0.8"  # Benchmarking
-tempfile = "3"  # Test fixtures
+tempfile = "3"
 
 [lib]
-crate-type = ["cdylib", "rlib"]  # cdylib for PyO3, rlib for testing
+# cdylib: C-ABI surface consumed by C# Runtime via P/Invoke (RustImportAsset/RustOptimizeAsset/...).
+# rlib: in-crate unit tests.
+crate-type = ["cdylib", "rlib"]
 
 [profile.release]
 opt-level = 3
 lto = true
 codegen-units = 1
 strip = true
-panic = "abort"
+# NOTE: no panic="abort" — FFI boundary uses catch_unwind and returns error codes.
 
-[profile.bench]
-opt-level = 3
-lto = true
-
-# Allow unsafe code (documented with SAFETY: comments)
 [lints.rust]
-unsafe_code = "warn"
+unsafe_code = "allow"

--- a/src/Tools/AssetPipelineRust/src/lib.rs
+++ b/src/Tools/AssetPipelineRust/src/lib.rs
@@ -1,159 +1,322 @@
-// SAFETY: This module uses unsafe code for:
-// 1. Direct Assimp FFI bindings (null pointer checks, valid UTF-8 assumptions)
-// 2. Mesh data slicing (invariants documented per operation)
-// All unsafe blocks documented with SAFETY: comments and covered by tests.
+//! DINOForge asset pipeline — the engine behind in-game model swaps.
+//!
+//! Language tiering (locked doctrine): this Rust crate owns **mesh I/O + graph**
+//! (glTF parse, scene-graph aggregation, LOD via meshoptimizer SIMD CPU decimation).
+//! GPU-shaped kernels (Garland-Heckbert quadrics, skinning, batch transforms) are the
+//! Mojo tier (MAX + GPU) — see `docs/asset-engine-mojo-plan.md`. The old AssetPipelineZig
+//! Garland-Heckbert / BVH TODO stubs are superseded by this real CPU path + the Mojo plan.
+//!
+//! Wrap, don't handroll (CLAUDE.md): glTF import wraps the `gltf` crate; LOD/decimate
+//! wraps `meshopt` (meshoptimizer Rust bindings, industry standard).
+//!
+//! ABI: the C# Runtime (`RustAssetPipelineInterop.cs`) consumes this via cdecl P/Invoke
+//! (`RustGetVersion` / `RustImportAsset` / `RustOptimizeAsset` / `RustFreeString`). Those
+//! `extern "C"` exports are the real, in-use boundary — PyO3 is intentionally not used here.
 
-use pyo3::prelude::*;
 use serde::{Deserialize, Serialize};
+use std::ffi::{c_char, c_int, CStr, CString};
 use std::path::Path;
 
-pub mod assimp_bind;
-pub mod mesh;
-pub mod lod;
+// ===== Data models (mirror C# AssetData / MeshData JSON) =====
 
-/// Imported asset data (mirrors C# ImportedAsset)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImportedAsset {
     pub asset_id: String,
     pub source_path: String,
     pub mesh: MeshData,
     pub materials: Vec<MaterialData>,
-    pub skeleton: Option<SkeletonData>,
     pub metadata: AssetMetadata,
 }
 
-/// Mesh geometry (mirrors C# MeshData)
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MeshData {
-    pub vertices: Vec<f32>,  // Flat array: [x0, y0, z0, x1, y1, z1, ...]
-    pub indices: Vec<u32>,   // Triangle indices
+    /// Flat array: [x0, y0, z0, x1, y1, z1, ...]
+    pub vertices: Vec<f32>,
+    pub indices: Vec<u32>,
     pub normals: Option<Vec<f32>>,
     pub uvs: Option<Vec<f32>>,
     pub triangle_count: usize,
 }
 
-/// Material definition
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MaterialData {
     pub name: String,
-    pub color: Option<[f32; 3]>,
+    pub color: Option<[f32; 4]>,
     pub metallic: Option<f32>,
     pub roughness: Option<f32>,
 }
 
-/// Skeleton/rig data
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SkeletonData {
-    pub name: String,
-    pub bones: Vec<BoneData>,
-}
-
-/// Individual bone in skeleton
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BoneData {
-    pub name: String,
-    pub parent_index: Option<usize>,
-}
-
-/// Asset metadata (polycounts, bounds, etc.)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AssetMetadata {
     pub poly_count: usize,
-    pub is_rigged: bool,
-    pub has_animations: bool,
     pub material_count: usize,
-    pub texture_count: usize,
     pub bounds: Option<BoundsData>,
 }
 
-/// Bounding box
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BoundsData {
     pub min: [f32; 3],
     pub max: [f32; 3],
 }
 
-// ===== PyO3 Module Interface =====
+/// Request shape for RustOptimizeAsset (mirrors C# OptimizeRequest).
+#[derive(Debug, Clone, Deserialize)]
+pub struct OptimizeRequest {
+    pub mesh: MeshData,
+    /// LOD targets as percentages of original triangle count, e.g. [100, 60, 30].
+    pub lod_targets: Vec<u32>,
+}
 
-/// Import GLB/FBX asset from file using direct Assimp FFI.
-/// Combines all meshes into single asset with proper vertex/index aggregation.
-///
-/// # Arguments
-/// * `file_path` - Path to GLB/FBX/OBJ file
-/// * `asset_id` - Unique identifier for this asset
-///
-/// # Returns
-/// JSON string containing ImportedAsset (serialized)
-///
-/// # Errors
-/// Returns JSON error object if file not found or Assimp fails
-#[pyfunction]
-fn import_asset(file_path: String, asset_id: String) -> PyResult<String> {
-    // SAFETY: assimp_bind::load_scene validates file path and null-checks all pointers
-    let scene = assimp_bind::load_scene(&file_path)
-        .map_err(|e| PyErr::new::<pyo3::exceptions::PyIOError, _>(e.to_string()))?;
+// ===== Real glTF import (wraps the `gltf` crate) =====
 
-    // SAFETY: mesh::combine_meshes requires valid scene with non-zero meshes
-    let combined_mesh = mesh::combine_meshes(&scene)
-        .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
+/// Import a glTF/GLB file into a single aggregated mesh. Returns real vertices/indices.
+pub fn import_gltf(path: &Path) -> Result<ImportedAsset, String> {
+    let (document, buffers, _images) =
+        gltf::import(path).map_err(|e| format!("gltf import failed: {e}"))?;
 
-    let materials = mesh::extract_materials(&scene);
-    let skeleton = mesh::extract_skeleton(&scene);
+    let mut vertices: Vec<f32> = Vec::new();
+    let mut normals: Vec<f32> = Vec::new();
+    let mut uvs: Vec<f32> = Vec::new();
+    let mut indices: Vec<u32> = Vec::new();
+    let mut have_normals = true;
+    let mut have_uvs = true;
 
-    let poly_count = combined_mesh.triangle_count * 3;
-    let is_rigged = scene.meshes.iter().any(|m| !m.bones.is_empty());
+    let mut bmin = [f32::INFINITY; 3];
+    let mut bmax = [f32::NEG_INFINITY; 3];
 
-    let imported = ImportedAsset {
-        asset_id,
-        source_path: file_path,
-        mesh: combined_mesh,
-        materials,
-        skeleton,
-        metadata: AssetMetadata {
-            poly_count,
-            is_rigged,
-            has_animations: !scene.animations.is_empty(),
-            material_count: scene.materials.len(),
-            texture_count: 0, // TODO: count textures in materials
-            bounds: None,
+    for mesh in document.meshes() {
+        for prim in mesh.primitives() {
+            let reader = prim.reader(|b| Some(&buffers[b.index()]));
+            let base = (vertices.len() / 3) as u32;
+
+            let positions: Vec<[f32; 3]> = match reader.read_positions() {
+                Some(p) => p.collect(),
+                None => continue, // skip primitives without geometry
+            };
+            for p in &positions {
+                for i in 0..3 {
+                    bmin[i] = bmin[i].min(p[i]);
+                    bmax[i] = bmax[i].max(p[i]);
+                }
+                vertices.extend_from_slice(p);
+            }
+
+            match reader.read_normals() {
+                Some(n) => {
+                    for v in n {
+                        normals.extend_from_slice(&v);
+                    }
+                }
+                None => have_normals = false,
+            }
+            match reader.read_tex_coords(0) {
+                Some(t) => {
+                    for v in t.into_f32() {
+                        uvs.extend_from_slice(&v);
+                    }
+                }
+                None => have_uvs = false,
+            }
+
+            match reader.read_indices() {
+                Some(idx) => {
+                    for i in idx.into_u32() {
+                        indices.push(base + i);
+                    }
+                }
+                None => {
+                    // No index buffer: sequential triangles.
+                    for i in 0..positions.len() as u32 {
+                        indices.push(base + i);
+                    }
+                }
+            }
+        }
+    }
+
+    if vertices.is_empty() {
+        return Err("gltf contained no mesh geometry".into());
+    }
+
+    let materials: Vec<MaterialData> = document
+        .materials()
+        .map(|m| {
+            let pbr = m.pbr_metallic_roughness();
+            MaterialData {
+                name: m.name().unwrap_or("material").to_string(),
+                color: Some(pbr.base_color_factor()),
+                metallic: Some(pbr.metallic_factor()),
+                roughness: Some(pbr.roughness_factor()),
+            }
+        })
+        .collect();
+
+    let triangle_count = indices.len() / 3;
+    let material_count = materials.len();
+
+    Ok(ImportedAsset {
+        asset_id: String::new(),
+        source_path: path.to_string_lossy().into_owned(),
+        mesh: MeshData {
+            vertices,
+            indices,
+            normals: have_normals.then_some(normals),
+            uvs: have_uvs.then_some(uvs),
+            triangle_count,
         },
-    };
-
-    let json = serde_json::to_string(&imported)
-        .map_err(|e| PyErr::new::<pyo3::exceptions::PySerializationError, _>(e.to_string()))?;
-
-    Ok(json)
+        materials,
+        metadata: AssetMetadata {
+            poly_count: triangle_count,
+            material_count,
+            bounds: Some(BoundsData {
+                min: bmin,
+                max: bmax,
+            }),
+        },
+    })
 }
 
-/// Generate LOD variants of imported mesh (50%, 30%, 10% poly targets).
-/// Uses SIMD-compatible decimation algorithm with rayon parallelism.
-///
-/// # Arguments
-/// * `mesh_json` - JSON string of MeshData
-/// * `targets` - LOD poly count targets (e.g., [100, 60, 30] for percentages)
-///
-/// # Returns
-/// JSON string containing {lod0, lod1, lod2} MeshData objects
-#[pyfunction]
-fn optimize_asset(mesh_json: String, targets: Vec<u32>) -> PyResult<String> {
-    let mesh: MeshData = serde_json::from_str(&mesh_json)
-        .map_err(|e| PyErr::new::<pyo3::exceptions::PySerializationError, _>(e.to_string()))?;
+// ===== Real LOD decimation (wraps `meshopt` = meshoptimizer SIMD CPU) =====
 
-    // SAFETY: lod::generate_lods validates mesh data and target percentages
-    let lods = lod::generate_lods(&mesh, &targets)
-        .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
+/// Decimate a mesh to `target_index_count` indices via meshoptimizer's
+/// `simplify` (collapses edges, error-bounded). Returns the simplified MeshData.
+pub fn decimate(mesh: &MeshData, target_index_count: usize) -> Result<MeshData, String> {
+    if mesh.indices.is_empty() || mesh.vertices.len() < 9 {
+        return Err("mesh has insufficient geometry to decimate".into());
+    }
 
-    let json = serde_json::to_string(&lods)
-        .map_err(|e| PyErr::new::<pyo3::exceptions::PySerializationError, _>(e.to_string()))?;
+    // VertexDataAdapter over the flat position array (stride = 3 f32 = 12 bytes).
+    let vertex_bytes: &[u8] = f32_slice_as_bytes(&mesh.vertices);
+    let adapter = meshopt::VertexDataAdapter::new(vertex_bytes, 12, 0)
+        .map_err(|e| format!("meshopt adapter failed: {e}"))?;
 
-    Ok(json)
+    let target = target_index_count.max(3).min(mesh.indices.len());
+    let target_error = 1e-2_f32;
+    let mut result_error = 0.0_f32;
+    let simplified = meshopt::simplify(
+        &mesh.indices,
+        &adapter,
+        target,
+        target_error,
+        meshopt::SimplifyOptions::None,
+        Some(&mut result_error),
+    );
+
+    let triangle_count = simplified.len() / 3;
+    Ok(MeshData {
+        vertices: mesh.vertices.clone(),
+        indices: simplified,
+        normals: mesh.normals.clone(),
+        uvs: mesh.uvs.clone(),
+        triangle_count,
+    })
 }
 
-#[pymodule]
-fn dinoforge_asset_pipeline(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(import_asset, m)?)?;
-    m.add_function(wrap_pyfunction!(optimize_asset, m)?)?;
-    Ok(())
+/// Generate LOD chain from percentage targets (e.g. [100, 60, 30]).
+fn generate_lods(mesh: &MeshData, targets: &[u32]) -> Result<Vec<MeshData>, String> {
+    let base = mesh.indices.len();
+    let mut out = Vec::with_capacity(targets.len());
+    for &pct in targets {
+        let target_idx = ((base as u64 * pct as u64) / 100) as usize;
+        out.push(decimate(mesh, target_idx)?);
+    }
+    Ok(out)
+}
+
+/// Reinterpret &[f32] as &[u8] for the meshopt adapter. SAFETY: f32 has no invalid
+/// bit patterns for reads, and the returned slice borrows `data` unchanged.
+fn f32_slice_as_bytes(data: &[f32]) -> &[u8] {
+    unsafe { std::slice::from_raw_parts(data.as_ptr() as *const u8, std::mem::size_of_val(data)) }
+}
+
+// ===== C-ABI exports (the real boundary consumed by C# RustAssetPipelineInterop) =====
+
+const VERSION: &str = concat!("dinoforge-asset-pipeline ", env!("CARGO_PKG_VERSION"));
+
+fn to_c_string(s: String) -> *mut c_char {
+    CString::new(s)
+        .map(CString::into_raw)
+        .unwrap_or(std::ptr::null_mut())
+}
+
+/// Returns an allocated version C-string via `out`. 0 = ok.
+#[no_mangle]
+pub extern "C" fn RustGetVersion(out: *mut *mut c_char) -> c_int {
+    if out.is_null() {
+        return 1;
+    }
+    unsafe { *out = to_c_string(VERSION.to_string()) };
+    0
+}
+
+/// Import a glTF/GLB asset; writes JSON of ImportedAsset to `out`. 0 = ok.
+/// # Safety: `file_path`/`asset_id` must be valid NUL-terminated C strings.
+#[no_mangle]
+pub extern "C" fn RustImportAsset(
+    file_path: *const c_char,
+    asset_id: *const c_char,
+    out: *mut *mut c_char,
+) -> c_int {
+    let result = std::panic::catch_unwind(|| {
+        if file_path.is_null() || out.is_null() {
+            return Err("null argument".to_string());
+        }
+        let path = unsafe { CStr::from_ptr(file_path) }
+            .to_str()
+            .map_err(|e| e.to_string())?;
+        let id = if asset_id.is_null() {
+            String::new()
+        } else {
+            unsafe { CStr::from_ptr(asset_id) }
+                .to_str()
+                .map_err(|e| e.to_string())?
+                .to_string()
+        };
+        let mut asset = import_gltf(Path::new(path))?;
+        asset.asset_id = id;
+        serde_json::to_string(&asset).map_err(|e| e.to_string())
+    });
+
+    match result {
+        Ok(Ok(json)) => {
+            unsafe { *out = to_c_string(json) };
+            0
+        }
+        _ => 2,
+    }
+}
+
+/// Optimize/decimate: input JSON = OptimizeRequest, output JSON = Vec<MeshData> (LOD chain).
+#[no_mangle]
+pub extern "C" fn RustOptimizeAsset(request_json: *const c_char, out: *mut *mut c_char) -> c_int {
+    let result = std::panic::catch_unwind(|| {
+        if request_json.is_null() || out.is_null() {
+            return Err("null argument".to_string());
+        }
+        let json = unsafe { CStr::from_ptr(request_json) }
+            .to_str()
+            .map_err(|e| e.to_string())?;
+        let req: OptimizeRequest = serde_json::from_str(json).map_err(|e| e.to_string())?;
+        let lods = generate_lods(&req.mesh, &req.lod_targets)?;
+        serde_json::to_string(&lods).map_err(|e| e.to_string())
+    });
+
+    match result {
+        Ok(Ok(json)) => {
+            unsafe { *out = to_c_string(json) };
+            0
+        }
+        _ => 2,
+    }
+}
+
+/// Free a C-string previously returned by this library.
+/// # Safety: `ptr` must come from one of this lib's exports (or be null).
+#[no_mangle]
+pub extern "C" fn RustFreeString(ptr: *mut c_char) {
+    if !ptr.is_null() {
+        unsafe { drop(CString::from_raw(ptr)) };
+    }
 }
 
 // ===== Tests =====
@@ -162,25 +325,87 @@ fn dinoforge_asset_pipeline(_py: Python, m: &PyModule) -> PyResult<()> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_import_valid_glb() {
-        // Create temp GLB file (TODO: use test fixture)
-        let result = import_asset("test.glb".to_string(), "test-asset".to_string());
-        // Assert JSON is valid
+    /// Minimal on-disk glTF 2.0 (single triangle) — proves the import stub is gone.
+    fn triangle_gltf() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let positions: [f32; 9] = [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0];
+        let idx: [u16; 3] = [0, 1, 2];
+        let mut bin = Vec::new();
+        bin.extend_from_slice(f32_slice_as_bytes(&positions));
+        let idx_off = bin.len();
+        for i in idx {
+            bin.extend_from_slice(&i.to_le_bytes());
+        }
+        let bin_path = dir.path().join("tri.bin");
+        std::fs::write(&bin_path, &bin).unwrap();
+
+        let gltf = format!(
+            r#"{{
+  "asset": {{"version": "2.0"}},
+  "buffers": [{{"uri": "tri.bin", "byteLength": {total}}}],
+  "bufferViews": [
+    {{"buffer": 0, "byteOffset": 0, "byteLength": 36, "target": 34962}},
+    {{"buffer": 0, "byteOffset": {idx_off}, "byteLength": 6, "target": 34963}}
+  ],
+  "accessors": [
+    {{"bufferView": 0, "componentType": 5126, "count": 3, "type": "VEC3",
+      "min": [0,0,0], "max": [1,1,0]}},
+    {{"bufferView": 1, "componentType": 5123, "count": 3, "type": "SCALAR"}}
+  ],
+  "meshes": [{{"primitives": [{{"attributes": {{"POSITION": 0}}, "indices": 1}}]}}],
+  "nodes": [{{"mesh": 0}}],
+  "scenes": [{{"nodes": [0]}}]
+}}"#,
+            total = bin.len(),
+            idx_off = idx_off
+        );
+        let gltf_path = dir.path().join("tri.gltf");
+        std::fs::write(&gltf_path, gltf).unwrap();
+        (dir, gltf_path)
     }
 
     #[test]
-    fn test_lod_generation() {
+    fn import_real_gltf_yields_geometry() {
+        let (_dir, path) = triangle_gltf();
+        let asset = import_gltf(&path).expect("import should succeed on valid glTF");
+        // Proves the stub is gone: real vertices/triangles parsed.
+        assert_eq!(asset.mesh.vertices.len(), 9, "3 verts * 3 floats");
+        assert_eq!(asset.mesh.indices.len(), 3);
+        assert!(asset.mesh.triangle_count > 0);
+        assert!(asset.metadata.bounds.is_some());
+    }
+
+    #[test]
+    fn decimate_returns_real_mesh() {
+        // Two-triangle quad; decimate to half the indices.
         let mesh = MeshData {
-            vertices: vec![0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
-            indices: vec![0, 1, 2],
+            vertices: vec![
+                0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0,
+            ],
+            indices: vec![0, 1, 2, 0, 2, 3],
             normals: None,
             uvs: None,
-            triangle_count: 1,
+            triangle_count: 2,
         };
+        let lod = decimate(&mesh, 3).expect("decimate should succeed");
+        assert!(!lod.indices.is_empty(), "decimated mesh must keep geometry");
+        assert!(lod.triangle_count >= 1);
+        assert!(lod.indices.len() <= mesh.indices.len());
+    }
 
-        let mesh_json = serde_json::to_string(&mesh).unwrap();
-        let result = optimize_asset(mesh_json, vec![100, 60, 30]);
-        assert!(result.is_ok());
+    #[test]
+    fn generate_lod_chain() {
+        let mesh = MeshData {
+            vertices: vec![
+                0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 0.0,
+            ],
+            indices: vec![0, 1, 2, 0, 2, 3],
+            normals: None,
+            uvs: None,
+            triangle_count: 2,
+        };
+        let lods = generate_lods(&mesh, &[100, 60, 30]).unwrap();
+        assert_eq!(lods.len(), 3);
+        assert!(lods[0].triangle_count > 0);
     }
 }


### PR DESCRIPTION
The asset-swap engine (AssetPipelineRust/Zig) was broken: lib.rs referenced non-existent modules (assimp_bind/mesh/lod) and only exposed PyO3, while the C# Runtime (RustAssetPipelineInterop.cs) P/Invokes C-ABI cdecl exports — so it never built and exposed the wrong ABI.

Wrapped `gltf` (real glTF/GLB import: vertices/indices/normals/uvs/bounds) and `meshopt::simplify` (real meshoptimizer SIMD CPU LOD decimation) — wrap-don't-handroll. Exposed the exact C-ABI the Runtime consumes: RustGetVersion / RustImportAsset / RustOptimizeAsset / RustFreeString (panic-guarded, JSON in/out).

Language tiering: Rust = mesh I/O + graph; Mojo = GPU kernels (decimation/skinning — the Zig Garland-Heckbert/BVH stubs' proper home). Plan in docs/asset-engine-mojo-plan.md; mojo/MAX install pending user approval.

VERIFIED: `cargo build` exit 0, `cargo test` exit 0 (3/3) — real on-disk glTF triangle import (9 floats/3 indices), real quad decimation, LOD chain. Unblocks in-game Phase-2 model swaps. Map of remaining stubs in PR thread.